### PR TITLE
feat: 优化实例管理

### DIFF
--- a/PCL.Mac/App/AppRouter.swift
+++ b/PCL.Mac/App/AppRouter.swift
@@ -13,7 +13,7 @@ enum AppRoute: Identifiable, Hashable, Equatable {
     case launch, download, multiplayer, settings, more, tasks
     
     // 启动页面的子页面
-    case instanceList(MinecraftRepository), noInstanceRepository, instanceSettings
+    case instanceList(MinecraftRepository), noInstanceRepository, instanceSettings(String)
     
     // 下载页面的子页面
     case minecraftDownload, downloadPage2, downloadPage3
@@ -89,7 +89,7 @@ class AppRouter: ObservableObject {
         switch getLast() {
         case .tasks: "任务列表"
         case .instanceList, .noInstanceRepository: "实例列表"
-        case .instanceSettings: "实例设置"
+        case .instanceSettings(let id): "实例设置 - \(id)"
         default: "错误：当前页面没有标题，请报告此问题！"
         }
     }

--- a/PCL.Mac/App/LauncherConfig.swift
+++ b/PCL.Mac/App/LauncherConfig.swift
@@ -50,7 +50,7 @@ public class LauncherConfig: Codable {
         } else {
             log("正在设置默认目录")
             var url: URL = FileManager.default.homeDirectoryForCurrentUser.appending(path: "Library/Application Support/minecraft")
-            if !FileManager.default.fileExists(atPath: url.path) { // 若官启（与 HMCL）目录不存在，使用未被隐藏且较浅的 ~/minecraft 目录
+            if !FileManager.default.fileExists(atPath: url.appending(path: "versions").path) { // 若官启（与 HMCL）目录不存在，使用未被隐藏且较浅的 ~/minecraft 目录
                 url = FileManager.default.homeDirectoryForCurrentUser.appending(path: "minecraft")
             }
             log("默认目录路径：\(url.path)")

--- a/PCL.Mac/Components/MyListItem.swift
+++ b/PCL.Mac/Components/MyListItem.swift
@@ -10,36 +10,66 @@ import SwiftUI
 struct MyListItem<Content: View>: View {
     @State private var hovered: Bool = false
     @State private var backgroundScale: CGFloat = 0.92
+    private let buttons: [Button]
     private let content: (Bool) -> Content
     
-    init(_ content: @escaping (Bool) -> Content) {
+    init(buttons: [Button] = [], _ content: @escaping (Bool) -> Content) {
+        self.buttons = buttons
         self.content = content
     }
     
-    init(_ content: @escaping () -> Content) {
-        self.init({ _ in content() })
+    init(buttons: [Button] = [], _ content: @escaping () -> Content) {
+        self.init(buttons: buttons, { _ in content() })
     }
     
     var body: some View {
-        content(hovered)
-            .frame(maxWidth: .infinity)
-            .padding(4)
-            .contentShape(Rectangle())
-            .background {
-                RoundedRectangle(cornerRadius: 4)
-                    .fill(hovered ? Color.color2.opacity(0.1) : .clear)
-                    .scaleEffect(backgroundScale)
-            }
-            .onHover { hovered in
-                withAnimation(.spring(response: 0.2)) {
-                    self.hovered = hovered
-                    if hovered {
-                        backgroundScale = 1
-                    } else {
-                        backgroundScale = 0.92
+        HStack {
+            content(hovered)
+            Spacer(minLength: 0)
+            if hovered {
+                HStack {
+                    ForEach(buttons, id: \.id) { button in
+                        Image(button.image)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 16, height: 16)
+                            .contentShape(.rect)
+                            .onTapGesture(perform: button.action)
                     }
                 }
+                .padding(.trailing, 8)
+                .foregroundStyle(Color.color4)
             }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(4)
+        .contentShape(Rectangle())
+        .background {
+            RoundedRectangle(cornerRadius: 4)
+                .fill(hovered ? Color.color2.opacity(0.1) : .clear)
+                .scaleEffect(backgroundScale)
+        }
+        .onHover { hovered in
+            withAnimation(.spring(response: 0.2)) {
+                self.hovered = hovered
+                if hovered {
+                    backgroundScale = 1
+                } else {
+                    backgroundScale = 0.92
+                }
+            }
+        }
+    }
+    
+    struct Button {
+        let id: UUID = .init()
+        let image: String
+        let action: () -> Void
+        
+        init(_ image: String, _ action: @escaping () -> Void) {
+            self.image = image
+            self.action = action
+        }
     }
 }
 

--- a/PCL.Mac/ViewModels/InstanceListViewModel.swift
+++ b/PCL.Mac/ViewModels/InstanceListViewModel.swift
@@ -36,9 +36,9 @@ class InstanceListViewModel: ObservableObject {
                 err("加载实例列表失败：\(error.localizedDescription)")
                 await MainActor.run {
                     loadingViewModel.fail(with: "加载失败：\(error.localizedDescription)")
-                    loadTask = nil
                 }
             }
+            loadTask = nil
         }
     }
     

--- a/PCL.Mac/ViewModels/InstanceViewModel.swift
+++ b/PCL.Mac/ViewModels/InstanceViewModel.swift
@@ -95,4 +95,10 @@ class InstanceViewModel: ObservableObject {
             addRepository(url: url)
         }
     }
+    
+    /// 打开实例设置。
+    /// - Parameter id: 实例的 ID。
+    public func openSettings(for id: String) {
+        AppRouter.shared.append(.instanceSettings(id))
+    }
 }

--- a/PCL.Mac/Views/Launch/InstanceList/InstanceListPage.swift
+++ b/PCL.Mac/Views/Launch/InstanceList/InstanceListPage.swift
@@ -45,6 +45,7 @@ struct InstanceListPage: View {
             }
         }
         .onAppear {
+            viewModel.switchRepository(to: repository)
             if repository.instances != nil { return }
             Task {
                 do {
@@ -62,6 +63,7 @@ struct InstanceListPage: View {
 }
 
 private struct InstanceView: View {
+    @EnvironmentObject private var viewModel: InstanceViewModel
     private let id: String
     private let version: MinecraftVersion
     
@@ -71,7 +73,9 @@ private struct InstanceView: View {
     }
     
     var body: some View {
-        MyListItem {
+        MyListItem(buttons: [
+            .init("SettingsPageIcon", { viewModel.openSettings(for: id) }),
+        ]) {
             HStack {
                 Image("GrassBlock")
                     .resizable()

--- a/PCL.Mac/Views/Launch/InstanceList/InstanceListPage.swift
+++ b/PCL.Mac/Views/Launch/InstanceList/InstanceListPage.swift
@@ -38,7 +38,7 @@ struct InstanceListPage: View {
             }
         }
         .onAppear {
-            viewModel.switchRepository(to: repository)
+            instanceViewModel.switchRepository(to: repository)
             if repository.instances != nil { return }
             viewModel.reloadAsync(repository)
         }

--- a/PCL.Mac/Views/Launch/InstanceSettings/InstanceSettingsView.swift
+++ b/PCL.Mac/Views/Launch/InstanceSettings/InstanceSettingsView.swift
@@ -1,0 +1,7 @@
+//
+//  InstanceSettingsView.swift
+//  PCL.Mac
+//
+//  Created by 温迪 on 2026/1/8.
+//
+

--- a/PCL.Mac/Views/Launch/LaunchSidebar.swift
+++ b/PCL.Mac/Views/Launch/LaunchSidebar.swift
@@ -43,8 +43,10 @@ struct LaunchSidebar: Sidebar {
                         router.append(.noInstanceRepository)
                     }
                 }
-                MyButton("实例设置") {
-                    router.append(.instanceSettings)
+                if let instance = instanceModel.currentInstance {
+                    MyButton("实例设置") {
+                        router.append(.instanceSettings(instance.name))
+                    }
                 }
             }
             .frame(height: 32)


### PR DESCRIPTION
本 PR 优化了实例管理逻辑，并添加了一些功能。
- 默认目录设置
默认目录为官方启动器目录（`~/Library/Application Support/minecraft`）。
若 `官启目录/versions` 不存在，会使用未被隐藏且更浅的 `~/minecraft`。
- 新功能
  - 目录改名与配置
  - 实例删除