### PR TITLE
chore: 将背景颜色改为浅蓝色

### DIFF
--- a/PCL.Mac/ContentView.swift
+++ b/PCL.Mac/ContentView.swift
@@ -27,7 +27,7 @@ struct ContentView: View {
                     }
                 router.content
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-                    .background(.green)
+                    .background(Color(0xC0DEF5))
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
为了界面相似度和遵守 PCL LICENSE，将背景颜色改为浅蓝色（非渐变）。