### PR TITLE
optimize: 移除 MyCard 折叠冷却

### DIFF
--- a/PCL.Mac/Components/MyCard.swift
+++ b/PCL.Mac/Components/MyCard.swift
@@ -22,7 +22,6 @@ struct MyCard<Content: View, Action: View>: View {
     @State private var contentHeight: CGFloat = 0
     /// `content()` 的高度限制。
     @State private var internalContentHeight: CGFloat = 0
-    @State private var lastClick: Date = .distantPast
     @State private var foldWorkItem: DispatchWorkItem?
     
     private let title: String
@@ -89,8 +88,6 @@ struct MyCard<Content: View, Action: View>: View {
             .contentShape(Rectangle())
             .onTapGesture {
                 guard foldable else { return }
-//                guard Date().timeIntervalSince(lastClick) > 0.2 else { return }
-                lastClick = Date()
                 self.foldWorkItem?.cancel()
                 if folded {
                     // 展开卡片


### PR DESCRIPTION
本 PR 使用 `DispatchWorkItem` 代替了原本折叠使用的 `DispatchQueue.asyncAfter(deadline:execute:)`，支持取消折叠。