### PR TITLE
feat(ci): 添加测试工作流

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       
@@ -26,10 +26,10 @@ jobs:
       - name: Build app
         run: |
           echo "Build number: $BUILD_NUMBER"
-          xcodebuild \
+          xcodebuild archive \
             -project PCL.Mac.xcodeproj -scheme PCL.Mac -configuration Debug \
             CURRENT_PROJECT_VERSION=$BUILD_NUMBER \
-            -archivePath build archive
+            -archivePath build
 
       - name: Prepare app artifact directory
         run: |
@@ -37,7 +37,7 @@ jobs:
           mv build.xcarchive/Products/Applications/PCL.Mac.app "./PCL.Mac-artifact/PCL.Mac.app"
 
       - name: Upload app artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: PCL.Mac.Refactor-${{ env.BUILD_NUMBER }}
           path: ./PCL.Mac-artifact

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -25,10 +25,10 @@ jobs:
           if [ -z "$PR_NUMBER" ]; then PR_NUMBER=0; fi
           BUILD_NUMBER=$(printf "%d%05d" "$PR_NUMBER" "$(git rev-list --count HEAD)")
 
-          xcodebuild \
+          xcodebuild archive \
           -project PCL.Mac.xcodeproj -scheme PCL.Mac -configuration Debug \
             CURRENT_PROJECT_VERSION=$BUILD_NUMBER \
-            -archivePath build archive
+            -archivePath build
 
       - name: Check build artifacts
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       
@@ -28,10 +28,10 @@ jobs:
 
       - name: Build app
         run: |
-          xcodebuild \
+          xcodebuild archive \
             -project PCL.Mac.xcodeproj -scheme PCL.Mac -configuration Release \
             CURRENT_PROJECT_VERSION=$BUILD_NUMBER \
-            -archivePath build archive
+            -archivePath build
 
       - name: Prepare release assets
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   test_macos_26:
+    name: Test on macOS 26
     if: ${{ github.event.inputs.macos_26 == 'true' }}
     runs-on: macos-26
     steps:
@@ -46,10 +47,11 @@ jobs:
       
       - name: Fail job if tests failed
         run: |
-          exit_code:="${XCODEBUILD_TEST_EXIT_CODE:-0}"
+          exit_code="${XCODEBUILD_TEST_EXIT_CODE:-0}"
           exit "${exit_code}"
 
   test_macos_15:
+    name: Test on macOS 15
     if: ${{ github.event.inputs.macos_15 == 'true' }}
     runs-on: macos-15
     steps:
@@ -80,10 +82,11 @@ jobs:
       
       - name: Fail job if tests failed
         run: |
-          exit_code:="${XCODEBUILD_TEST_EXIT_CODE:-0}"
+          exit_code="${XCODEBUILD_TEST_EXIT_CODE:-0}"
           exit "${exit_code}"
 
   test_macos_12:
+    name: Test on macOS 12
     if: ${{ github.event.inputs.macos_12 == 'true' }}
     runs-on: macos-12
     steps:
@@ -114,5 +117,5 @@ jobs:
       
       - name: Fail job if tests failed
         run: |
-          exit_code:="${XCODEBUILD_TEST_EXIT_CODE:-0}"
+          exit_code="${XCODEBUILD_TEST_EXIT_CODE:-0}"
           exit "${exit_code}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,118 @@
+on:
+  workflow_dispatch:
+    input:
+      macos_26:
+        description: "macOS 26"
+        type: boolean
+        default: true
+      macos_15:
+        description: "macOS 15"
+        type: boolean
+        default: false
+      macos_12:
+        description: "macOS 12"
+        type: boolean
+        default: false
+
+jobs:
+  test_macos_26:
+    if: ${{ github.event.inputs.macos_26 == 'true' }}
+    runs-on: macos-26
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Run tests
+        run: |
+          set +e
+
+          xcodebuild test \
+            -project PCL.Mac.xcodeproj -scheme PCL.Mac \
+            -resultBundlePath ./result.xcresult
+          
+          exit_code=$?
+          echo "TEST_EXIT_CODE=$exit_code" >> "$GITHUB_ENV"
+
+          set -e
+        continue-on-error: true
+      
+      - name: Upload result
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-26.xcresult
+          path: result.xcresult
+      
+      - name: Fail job if tests failed
+        run: |
+          exit_code:="${XCODEBUILD_TEST_EXIT_CODE:-0}"
+          exit "${exit_code}"
+
+  test_macos_15:
+    if: ${{ github.event.inputs.macos_15 == 'true' }}
+    runs-on: macos-15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Run tests
+        run: |
+          set +e
+
+          xcodebuild test \
+            -project PCL.Mac.xcodeproj -scheme PCL.Mac \
+            -resultBundlePath ./result.xcresult
+          
+          exit_code=$?
+          echo "TEST_EXIT_CODE=$exit_code" >> "$GITHUB_ENV"
+
+          set -e
+        continue-on-error: true
+      
+      - name: Upload result
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-15.xcresult
+          path: result.xcresult
+      
+      - name: Fail job if tests failed
+        run: |
+          exit_code:="${XCODEBUILD_TEST_EXIT_CODE:-0}"
+          exit "${exit_code}"
+
+  test_macos_12:
+    if: ${{ github.event.inputs.macos_12 == 'true' }}
+    runs-on: macos-12
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Run tests
+        run: |
+          set +e
+
+          xcodebuild test \
+            -project PCL.Mac.xcodeproj -scheme PCL.Mac \
+            -resultBundlePath ./result.xcresult
+          
+          exit_code=$?
+          echo "TEST_EXIT_CODE=$exit_code" >> "$GITHUB_ENV"
+
+          set -e
+        continue-on-error: true
+      
+      - name: Upload result
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-12.xcresult
+          path: result.xcresult
+      
+      - name: Fail job if tests failed
+        run: |
+          exit_code:="${XCODEBUILD_TEST_EXIT_CODE:-0}"
+          exit "${exit_code}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
       
       - name: Fail job if tests failed
         run: |
-          exit_code="${XCODEBUILD_TEST_EXIT_CODE:-0}"
+          exit_code="${TEST_EXIT_CODE:-0}"
           exit "${exit_code}"
 
   test_macos_15:
@@ -79,5 +79,5 @@ jobs:
       
       - name: Fail job if tests failed
         run: |
-          exit_code="${XCODEBUILD_TEST_EXIT_CODE:-0}"
+          exit_code="${TEST_EXIT_CODE:-0}"
           exit "${exit_code}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       
@@ -37,7 +37,7 @@ jobs:
         continue-on-error: true
       
       - name: Upload result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-26.xcresult
           path: result.xcresult
@@ -53,7 +53,7 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       
@@ -72,7 +72,7 @@ jobs:
         continue-on-error: true
       
       - name: Upload result
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-15.xcresult
           path: result.xcresult

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 on:
   workflow_dispatch:
-    input:
+    inputs:
       macos_26:
         description: "macOS 26"
         type: boolean

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,10 +9,6 @@ on:
         description: "macOS 15"
         type: boolean
         default: false
-      macos_12:
-        description: "macOS 12"
-        type: boolean
-        default: false
 
 jobs:
   test_macos_26:
@@ -78,41 +74,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: macos-15.xcresult
-          path: result.xcresult
-      
-      - name: Fail job if tests failed
-        run: |
-          exit_code="${XCODEBUILD_TEST_EXIT_CODE:-0}"
-          exit "${exit_code}"
-
-  test_macos_12:
-    name: Test on macOS 12
-    if: ${{ github.event.inputs.macos_12 == 'true' }}
-    runs-on: macos-12
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      
-      - name: Run tests
-        run: |
-          set +e
-
-          xcodebuild test \
-            -project PCL.Mac.xcodeproj -scheme PCL.Mac \
-            -resultBundlePath ./result.xcresult
-          
-          exit_code=$?
-          echo "TEST_EXIT_CODE=$exit_code" >> "$GITHUB_ENV"
-
-          set -e
-        continue-on-error: true
-      
-      - name: Upload result
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos-12.xcresult
           path: result.xcresult
       
       - name: Fail job if tests failed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,4 @@
+name: Run Tests
 on:
   workflow_dispatch:
     inputs:

--- a/PCL.Mac.Tests/DownloadTests.swift
+++ b/PCL.Mac.Tests/DownloadTests.swift
@@ -56,7 +56,7 @@ struct DownloadTests {
     }
     
     @Test func multiFileDownloadTest() async throws {
-        if ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true" {
+        if ProcessInfo.processInfo.environment["GITHUB_ENV"] != nil {
             print("当前环境为 GitHub Actions，跳过多文件下载测试")
             return
         }

--- a/PCL.Mac.Tests/DownloadTests.swift
+++ b/PCL.Mac.Tests/DownloadTests.swift
@@ -56,6 +56,10 @@ struct DownloadTests {
     }
     
     @Test func multiFileDownloadTest() async throws {
+        if ProcessInfo.processInfo.environment["GITHUB_ACTIONS"] == "true" {
+            print("当前环境为 GitHub Actions，跳过多文件下载测试")
+            return
+        }
         let data: Data = try await URLSession.shared.data(from: URL(string: "https://piston-meta.mojang.com/v1/packages/48fc0ab195b88bc562d672cdcf7997de42fe9d51/27.json").unwrap()).0
         let assetIndex: AssetIndex = try JSONDecoder.shared.decode(AssetIndex.self, from: data)
         let tempDirectory: URL = URLConstants.tempURL.appending(path: "multiFileDownloadTest")

--- a/PCL.Mac.Tests/Minecraft/MinecraftLoadTests.swift
+++ b/PCL.Mac.Tests/Minecraft/MinecraftLoadTests.swift
@@ -12,6 +12,9 @@ import Testing
 struct MinecraftLoadTests {
     @Test private func testLoad() throws {
         let directory: URL = FileManager.default.temporaryDirectory.appending(path: "testLoad")
+        if FileManager.default.fileExists(atPath: directory.path) {
+            try FileManager.default.removeItem(at: directory)
+        }
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
         defer { try? FileManager.default.removeItem(at: directory) }
         

--- a/PCL.Mac.Tests/Minecraft/MinecraftVersionTests.swift
+++ b/PCL.Mac.Tests/Minecraft/MinecraftVersionTests.swift
@@ -10,7 +10,8 @@ import Foundation
 import Core
 
 struct MinecraftVersionTests {
-    @Test func test() {
+    @Test func test() async throws {
+        CoreState.versionManifest = try await Requests.get("https://launchermeta.mojang.com/mc/game/version_manifest.json").decode(VersionManifest.self)
         #expect(MinecraftVersion("1.21.10") == MinecraftVersion("1.21.10"))
         #expect(MinecraftVersion("1.21.10") < MinecraftVersion("1.21.11-pre2"))
         #expect(MinecraftVersion("1.21") > MinecraftVersion("1.20.6"))


### PR DESCRIPTION
本 PR 添加了测试工作流（`test.yml`），可以在不同 macOS 版本（macOS 15/26）下运行 `PCL.Mac.Tests` 。