### PR TITLE
fix: 26w14a 未被正确分类为愚人节版本

### DIFF
--- a/PCL.Mac.Core/Models/VersionManifest.swift
+++ b/PCL.Mac.Core/Models/VersionManifest.swift
@@ -28,6 +28,15 @@ public struct VersionManifest: Decodable, Equatable {
     
     public struct Version: Decodable, Hashable {
         private static let aprilFoolVersions: [String] = ["15w14a", "1.rv-pre1", "3d shareware v1.34", "20w14infinite", "22w13oneblockatatime", "23w13a_or_b", "24w14potato", "25w14craftmine"]
+        private static let calendar: Calendar? = {
+            var calendar: Calendar = .init(identifier: .gregorian)
+            guard let timeZome: TimeZone = .init(identifier: "Europe/Stockholm") else {
+                err("创建 Europe/Stockholm 时区失败")
+                return nil
+            }
+            calendar.timeZone = timeZome
+            return calendar
+        }()
         
         public let id: String
         public let type: MinecraftVersion.VersionType
@@ -43,20 +52,27 @@ public struct VersionManifest: Decodable, Equatable {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.id = try container.decode(String.self, forKey: .id)
                 .replacingOccurrences(of: " Pre-Release ", with: "-pre")
+            self.releaseTime = try container.decode(Date.self, forKey: .releaseTime)
             var type: MinecraftVersion.VersionType = try container.decode(MinecraftVersion.VersionType.self, forKey: .type)
-            if type == .snapshot && Self.isAprilFoolVersion(id: id, type: type) {
+            if type == .snapshot && Self.isAprilFoolVersion(id: id, releaseTime: releaseTime) {
                 type = .aprilFool
             }
             self.type = type
             self.url = try container.decode(URL.self, forKey: .url)
             self.time = try container.decode(Date.self, forKey: .time)
-            self.releaseTime = try container.decode(Date.self, forKey: .releaseTime)
         }
         
-        private static func isAprilFoolVersion(id: String, type: MinecraftVersion.VersionType) -> Bool {
+        private static func isAprilFoolVersion(id: String, releaseTime: Date) -> Bool {
             if aprilFoolVersions.contains(id.lowercased()) { return true }
-            return type == .snapshot // 是快照
-            && !(id.count == 6 && Array(id)[2] == "w") // 且不是标准快照格式 (如 23w33a)
+            
+            if let calendar {
+                let components: DateComponents = calendar.dateComponents([.month, .day], from: releaseTime)
+                if let month: Int = components.month, let day: Int = components.day {
+                    return month == 4 && day == 1
+                }
+            }
+            
+            return !(id.count == 6 && Array(id)[2] == "w" && !id.starts(with: "26")) // 不是标准快照版本号格式 (如 23w33a)
             && id.rangeOfCharacter(from: .letters) != nil // 至少有一个字母 (筛掉 1.x 与 1.x.x)
             && !id.contains("-pre") && !id.contains("-rc") // 不是 Pre Release 或 Release Candidate
             && !id.contains("snapshot") // 不是新版本号格式的快照（如 26.1-snapshot-1）

--- a/PCL.Mac.Core/Models/VersionManifest.swift
+++ b/PCL.Mac.Core/Models/VersionManifest.swift
@@ -27,7 +27,6 @@ public struct VersionManifest: Decodable, Equatable {
     }
     
     public struct Version: Decodable, Hashable {
-        private static let aprilFoolVersions: [String] = ["15w14a", "1.rv-pre1", "3d shareware v1.34", "20w14infinite", "22w13oneblockatatime", "23w13a_or_b", "24w14potato", "25w14craftmine"]
         private static let calendar: Calendar? = {
             var calendar: Calendar = .init(identifier: .gregorian)
             guard let timeZome: TimeZone = .init(identifier: "Europe/Stockholm") else {
@@ -63,8 +62,6 @@ public struct VersionManifest: Decodable, Equatable {
         }
         
         private static func isAprilFoolVersion(id: String, releaseTime: Date) -> Bool {
-            if aprilFoolVersions.contains(id.lowercased()) { return true }
-            
             if let calendar {
                 let components: DateComponents = calendar.dateComponents([.month, .day], from: releaseTime)
                 if let month: Int = components.month, let day: Int = components.day {

--- a/PCL.Mac.Core/Models/VersionManifest.swift
+++ b/PCL.Mac.Core/Models/VersionManifest.swift
@@ -27,6 +27,7 @@ public struct VersionManifest: Decodable, Equatable {
     }
     
     public struct Version: Decodable, Hashable {
+        private static let aprilFoolVersions: [String] = ["15w14a", "1.rv-pre1", "3d shareware v1.34", "20w14infinite", "22w13oneblockatatime", "23w13a_or_b", "24w14potato", "25w14craftmine"]
         private static let calendar: Calendar? = {
             var calendar: Calendar = .init(identifier: .gregorian)
             guard let timeZome: TimeZone = .init(identifier: "Europe/Stockholm") else {
@@ -62,6 +63,8 @@ public struct VersionManifest: Decodable, Equatable {
         }
         
         private static func isAprilFoolVersion(id: String, releaseTime: Date) -> Bool {
+            if aprilFoolVersions.contains(id.lowercased()) { return true }
+            
             if let calendar {
                 let components: DateComponents = calendar.dateComponents([.month, .day], from: releaseTime)
                 if let month: Int = components.month, let day: Int = components.day {

--- a/PCL.Mac/ViewModels/MinecraftDownloadPageViewModel.swift
+++ b/PCL.Mac/ViewModels/MinecraftDownloadPageViewModel.swift
@@ -76,7 +76,8 @@ class MinecraftDownloadPageViewModel: ObservableObject {
         case "23w13a_or_b": "2023 | 研究表明：玩家喜欢作出选择——越多越好！"
         case "24w14potato": "2024 | 毒马铃薯一直都被大家忽视和低估，于是我们超级加强了它！"
         case "25w14craftmine": "2025 | 你可以合成任何东西——包括合成你的世界！"
-        default: "20?? | ???"
+        case "26w14a": "2026 | 为什么需要物品栏？让方块们跟着你走吧！"
+        default: "20?? | ???（当前版本的启动器中没有这个游戏版本的描述……）"
         }
     }
 }


### PR DESCRIPTION
本 PR 添加了通过日期判断愚人节版本的方式，仅在 `Calendar` 创建失败时才会进行版本号分析。