### PR TITLE
fix(ci): release.yml Download artifact 的工件名不正确 [skip ci]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Download artifact
         uses: actions/download-artifact@v8
         with:
-          name: artifact
+          name: PCL.Mac-artifact.tar.gz
           path: ./artifact.tar.gz
       
       - name: Process artifact


### PR DESCRIPTION
我真没招了