### PR TITLE
fix: YggdrasilService.refresh 不会附带 selectedProfile

### DIFF
--- a/PCL.Mac.Core/Extensions/Encodable+Dictionary.swift
+++ b/PCL.Mac.Core/Extensions/Encodable+Dictionary.swift
@@ -1,0 +1,16 @@
+//
+//  Encodable+Dictionary.swift
+//  PCL.Mac
+//
+//  Created by AnemoFlower on 2026/5/16.
+//
+
+import Foundation
+
+public extension Encodable {
+    func toDictionary() throws -> [String: Any] {
+        let data = try JSONEncoder.shared.encode(self)
+        let json = try JSONSerialization.jsonObject(with: data)
+        return json as? [String: Any] ?? [:]
+    }
+}

--- a/PCL.Mac.Core/Extensions/Encodable+Dictionary.swift
+++ b/PCL.Mac.Core/Extensions/Encodable+Dictionary.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public extension Encodable {
-    func toDictionary() throws -> [String: Any] {
+    func toDictionary() throws -> [String: Any]? {
         let data = try JSONEncoder.shared.encode(self)
         let json = try JSONSerialization.jsonObject(with: data)
         return json as? [String: Any] ?? [:]

--- a/PCL.Mac.Core/Extensions/JSONCoder+Shared.swift
+++ b/PCL.Mac.Core/Extensions/JSONCoder+Shared.swift
@@ -1,5 +1,5 @@
 //
-//  JSONCoderExtension.swift
+//  JSONCoder+Shared.swift
 //  PCL.Mac
 //
 //  Created by AnemoFlower on 2025/12/20.

--- a/PCL.Mac.Core/Models/Account/YggdrasilAccount.swift
+++ b/PCL.Mac.Core/Models/Account/YggdrasilAccount.swift
@@ -38,7 +38,7 @@ public class YggdrasilAccount: Account {
     }
     
     public func refresh() async throws {
-        let response = try await service.refresh(accessToken, clientToken: clientToken)
+        let response = try await service.refresh(accessToken, clientToken: clientToken, profile: profile)
         self.accessToken = response.accessToken
         if let profile = response.selectedProfile {
             let fullProfile: PlayerProfile = try await service.fullProfile(for: profile.id)

--- a/PCL.Mac.Core/Models/PlayerProfile.swift
+++ b/PCL.Mac.Core/Models/PlayerProfile.swift
@@ -36,7 +36,7 @@ public struct PlayerProfile: Codable {
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.name, forKey: .name)
-        try container.encode(UUIDUtils.string(of: self.id), forKey: .id)
+        try container.encode(UUIDUtils.string(of: self.id, withHyphens: false), forKey: .id)
         if !self.properties.isEmpty {
             try container.encode(self.properties, forKey: .properties)
         }

--- a/PCL.Mac.Core/Services/YggdrasilService.swift
+++ b/PCL.Mac.Core/Services/YggdrasilService.swift
@@ -93,14 +93,20 @@ public class YggdrasilService {
     /// - Parameters:
     ///   - accessToken: 令牌的 `accessToken`。
     ///   - clientToken: 令牌的 `clientToken`（可选）。
+    ///   - profile: 令牌绑定的角色。如果令牌处于无效状态，且此参数未被设置，将无法刷新。
     /// - Returns: 包含新 `accessToken` 和新角色档案（若发生变更）的 `RefreshResponse`。
-    public func refresh(_ accessToken: String, clientToken: String? = nil) async throws -> RefreshResponse {
+    public func refresh(
+        _ accessToken: String,
+        clientToken: String? = nil,
+        profile: PlayerProfile?
+    ) async throws -> RefreshResponse {
         let response = try await request(
             "POST", "/authserver/refresh",
             body: [
                 "accessToken": accessToken,
                 "clientToken": clientToken,
-                "requestUser": true
+                "requestUser": true,
+                "selectedProfile": try profile?.toDictionary()
             ]
         )
         


### PR DESCRIPTION
## Summary by Sourcery

Pass the bound player profile when refreshing Yggdrasil tokens so the selected profile is included, and adjust related encoding utilities.

New Features:
- Add a generic Encodable helper to convert models to dictionaries for use in JSON request bodies.

Bug Fixes:
- Include the selected player profile in Yggdrasil token refresh requests to fix refresh failures when the token is in an invalid state.
- Encode player profile UUIDs without hyphens to match the expected identifier format in requests.

Enhancements:
- Update JSON encoder shared extension filename to better reflect its purpose.
- Wire account refresh calls through the updated YggdrasilService.refresh API that accepts a player profile.