### PR TITLE
feat: 拖拽导入整合包

### DIFF
--- a/PCL.Mac.Core/Extensions/Encodable+Dictionary.swift
+++ b/PCL.Mac.Core/Extensions/Encodable+Dictionary.swift
@@ -11,6 +11,6 @@ public extension Encodable {
     func toDictionary() throws -> [String: Any]? {
         let data = try JSONEncoder.shared.encode(self)
         let json = try JSONSerialization.jsonObject(with: data)
-        return json as? [String: Any] ?? [:]
+        return json as? [String: Any]
     }
 }

--- a/PCL.Mac.Core/Services/ModpackImportService.swift
+++ b/PCL.Mac.Core/Services/ModpackImportService.swift
@@ -246,3 +246,24 @@ public class ModpackImportService {
         }
     }
 }
+
+
+public extension ModpackImportService {
+    static func isModpack(_ url: URL) -> Bool {
+        let archive: Archive
+        do {
+            archive = try Archive(url: url, accessMode: .read)
+        } catch {
+            return false
+        }
+        let service = ModpackImportService(modpackURL: url)
+        do {
+            _ = try service.loadIndex(from: archive)
+        } catch {
+            if case .unknownFormat = error {
+                return false
+            }
+        }
+        return true
+    }
+}

--- a/PCL.Mac.Core/Services/ModpackImportService.swift
+++ b/PCL.Mac.Core/Services/ModpackImportService.swift
@@ -260,6 +260,8 @@ public extension ModpackImportService {
                 return false
             } else if case .unknownFormat = error {
                 return false
+            } else if case .failedToDecodeIndex = error {
+                return false
             }
         }
         return true

--- a/PCL.Mac.Core/Services/ModpackImportService.swift
+++ b/PCL.Mac.Core/Services/ModpackImportService.swift
@@ -42,7 +42,9 @@ public class ModpackImportService {
             let nestedModpackURL = tempDirectory.appending(path: modpackEntry.path)
             let nestedArchive: Archive
             do {
-                _ = try archive.extract(modpackEntry, to: nestedModpackURL, allowUncontainedSymlinks: false)
+                if !FileManager.default.fileExists(atPath: nestedModpackURL.path) {
+                    _ = try archive.extract(modpackEntry, to: nestedModpackURL, allowUncontainedSymlinks: false)
+                }
                 nestedArchive = try .init(url: nestedModpackURL, accessMode: .read)
                 self.modpackURL = nestedModpackURL
             } catch {
@@ -250,17 +252,13 @@ public class ModpackImportService {
 
 public extension ModpackImportService {
     static func isModpack(_ url: URL) -> Bool {
-        let archive: Archive
-        do {
-            archive = try Archive(url: url, accessMode: .read)
-        } catch {
-            return false
-        }
         let service = ModpackImportService(modpackURL: url)
         do {
-            _ = try service.loadIndex(from: archive)
+            _ = try service.load()
         } catch {
-            if case .unknownFormat = error {
+            if case .extractFailed = error {
+                return false
+            } else if case .unknownFormat = error {
                 return false
             }
         }

--- a/PCL.Mac/Managers/FileDropHandler.swift
+++ b/PCL.Mac/Managers/FileDropHandler.swift
@@ -1,0 +1,20 @@
+//
+//  FileDropHandler.swift
+//  PCL.Mac
+//
+//  Created by AnemoFlower on 2026/5/21.
+//
+
+import Foundation
+import Core
+
+enum FileDropHandler {
+    static func handle(_ url: URL, instanceManager: InstanceManager) async {
+        if ModpackImportService.isModpack(url) {
+            let viewModel = ModpackViewModel(instanceManager: instanceManager)
+            await viewModel.importModpack(at: url, repository: instanceManager.currentRepository)
+        } else {
+            hint("无法识别 \(url.lastPathComponent) 的类型！", type: .critical)
+        }
+    }
+}

--- a/PCL.Mac/Views/ContentView.swift
+++ b/PCL.Mac/Views/ContentView.swift
@@ -45,14 +45,13 @@ struct ContentView: View {
         .contrast(easterEggManager.modifyColor ? -1 : 1)
         .onDrop(of: [UTType.fileURL], isTargeted: nil) { providers in
             guard let provider = providers.first else { return false }
-            provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier) { item, error in
+            _ = provider.loadObject(ofClass: URL.self) { item, error in
                 if let error {
                     err("处理拖拽失败：\(error.localizedDescription)")
                     hint("处理拖拽失败：\(error.localizedDescription)", type: .critical)
                     return
                 }
-                guard let data = item as? Data,
-                      let url = URL(dataRepresentation: data, relativeTo: nil) else {
+                guard let url = item else {
                     hint("处理拖拽失败：发生未知错误。", type: .critical)
                     return
                 }
@@ -224,8 +223,4 @@ private struct ExtraButtonsOverlay: View {
                 .animation(.spring(response: 0.4), value: show)
         }
     }
-}
-
-#Preview {
-    ContentView()
 }

--- a/PCL.Mac/Views/ContentView.swift
+++ b/PCL.Mac/Views/ContentView.swift
@@ -6,11 +6,15 @@
 //
 
 import SwiftUI
+import UniformTypeIdentifiers
+import Core
 
 struct ContentView: View {
     @ObservedObject private var hintManager: HintManager = .shared
     @ObservedObject private var router: AppRouter = .shared
     @ObservedObject private var easterEggManager: EasterEggManager = .shared
+    
+    @EnvironmentObject private var instanceManager: InstanceManager
     
     var body: some View {
         VStack(spacing: 0) {
@@ -39,6 +43,24 @@ struct ContentView: View {
         .background(Color(0xC0DEF5))
         .rotation3DEffect(easterEggManager.rotationAngle, axis: easterEggManager.rotationAxis)
         .contrast(easterEggManager.modifyColor ? -1 : 1)
+        .onDrop(of: [UTType.fileURL], isTargeted: nil) { providers in
+            guard let provider = providers.first else { return false }
+            provider.loadItem(forTypeIdentifier: UTType.fileURL.identifier) { item, error in
+                if let error {
+                    err("处理拖拽失败：\(error.localizedDescription)")
+                    hint("处理拖拽失败：\(error.localizedDescription)", type: .critical)
+                }
+                guard let data = item as? Data,
+                      let url = URL(dataRepresentation: data, relativeTo: nil) else {
+                    hint("处理拖拽失败：发生未知错误。", type: .critical)
+                    return
+                }
+                Task {
+                    await FileDropHandler.handle(url, instanceManager: instanceManager)
+                }
+            }
+            return true
+        }
     }
 }
 

--- a/PCL.Mac/Views/ContentView.swift
+++ b/PCL.Mac/Views/ContentView.swift
@@ -49,6 +49,7 @@ struct ContentView: View {
                 if let error {
                     err("处理拖拽失败：\(error.localizedDescription)")
                     hint("处理拖拽失败：\(error.localizedDescription)", type: .critical)
+                    return
                 }
                 guard let data = item as? Data,
                       let url = URL(dataRepresentation: data, relativeTo: nil) else {


### PR DESCRIPTION
closes #184

## Summary by Sourcery

Enable drag-and-drop handling of modpack files in the macOS app and centralize validation and import logic for dropped archives.

New Features:
- Support importing modpacks by dragging files into the main window.

Enhancements:
- Add a utility to detect whether a given archive is a valid modpack before importing.
- Adjust Encodable-to-dictionary conversion to return nil when JSON is not a dictionary instead of an empty dictionary.