### PR TITLE
chore: 从网络获取联机节点列表

### DIFF
--- a/PCL.Mac.Core/Services/CLAPIClient.swift
+++ b/PCL.Mac.Core/Services/CLAPIClient.swift
@@ -11,7 +11,7 @@ import SwiftyJSON
 public class CLAPIClient {
     public static let shared: CLAPIClient = .init()
     
-    private let apiRoot: URL = .init(string: "https://api.ceciliastudio.top")!
+    private let apiRoot: URL = .init(string: "https://api.cylorine.studio")!
     private let iso8601DateFormatter: ISO8601DateFormatter = .init()
     
     public func getCaveMessages() async throws -> [String] {
@@ -31,7 +31,7 @@ public class CLAPIClient {
     }
     
     public func getEasyTierPeers() async throws -> [String] {
-        return try await Requests.get("https://cylorine.studio/meta/PCL.Mac/easytier_peers.json", timeout: 10).decode([String].self)
+        try await get("/easytier/peers").arrayValue.map(\.stringValue)
     }
     
     private init() {}

--- a/PCL.Mac.Core/Services/CLAPIClient.swift
+++ b/PCL.Mac.Core/Services/CLAPIClient.swift
@@ -30,6 +30,10 @@ public class CLAPIClient {
         }
     }
     
+    public func getEasyTierPeers() async throws -> [String] {
+        return try await Requests.get("https://cylorine.studio/meta/PCL.Mac/easytier_peers.json", timeout: 10).decode([String].self)
+    }
+    
     private init() {}
     
     private func request(path: String, method: String, body: [String: Any]?) async throws -> Response {

--- a/PCL.Mac/Managers/EasyTierManager.swift
+++ b/PCL.Mac/Managers/EasyTierManager.swift
@@ -52,17 +52,13 @@ class EasyTierManager {
         }
     }
     
-    public func makeEasyTier() -> EasyTier {
+    public func makeEasyTier(peers: [String]) -> EasyTier {
         easyTierInstances.removeAll { $0.process == nil }
-        var options: [EasyTier.Option] = [
+        let options: [EasyTier.Option] = [
             .p2pOnly,
-            .peer(address: "tcp://public.easytier.top:11010"),
-            .peer(address: "tcp://public2.easytier.cn:54321"),
             .enableKcpProxy, .latencyFirst, .multiThread, .compression(algorithm: "zstd")
-        ]
-        if let customPeer = LauncherConfig.shared.multiplayerCustomPeer {
-            options.append(.peer(address: customPeer))
-        }
+        ] + peers.map(EasyTier.Option.peer(address:))
+        
         let instance: EasyTier = .init(coreURL: coreURL, cliURL: cliURL, logURL: logURL, options: options)
         easyTierInstances.append(instance)
         return instance

--- a/PCL.Mac/ViewModels/MultiplayerViewModel.swift
+++ b/PCL.Mac/ViewModels/MultiplayerViewModel.swift
@@ -20,6 +20,7 @@ class MultiplayerViewModel: ObservableObject {
     private var server: ScaffoldingServer?
     private var client: ScaffoldingClient?
     private var serverCheckTask: Task<Void, Swift.Error>?
+    private var peers: [String]?
     private let vendor: String = "PCL.Mac \(Metadata.appVersion), SwiftScaffolding 0.2.1, EasyTier v2.5.0"
     
     /// 创建并启动一个 Scaffolding 联机中心。
@@ -38,15 +39,17 @@ class MultiplayerViewModel: ObservableObject {
             }
             state = .creatingRoom
             let code: String = RoomCode.generate()
-            let server: ScaffoldingServer = .init(
-                easyTier: EasyTierManager.shared.makeEasyTier(),
-                roomCode: code,
-                serverPort: serverPort,
-                hostInfo: playerInfo()
-            )
-            registerCustomProtocols(to: server)
             Task.detached {
                 do {
+                    let peers = await self.peers()
+                    let server: ScaffoldingServer = .init(
+                        easyTier: EasyTierManager.shared.makeEasyTier(peers: peers),
+                        roomCode: code,
+                        serverPort: serverPort,
+                        hostInfo: self.playerInfo()
+                    )
+                    self.registerCustomProtocols(to: server)
+                    
                     _ = try await server.startListener()
                     try server.createRoom(terminationHandler: { [weak self] process in
                         guard let self else { return }
@@ -106,13 +109,15 @@ class MultiplayerViewModel: ObservableObject {
     ///   - playerName: 房客玩家名。
     @MainActor
     public func join(roomCode: String) {
-        let client: ScaffoldingClient = .init(
-            easyTier: EasyTierManager.shared.makeEasyTier(),
-            playerInfo: playerInfo()
-        )
         state = .joiningRoom
         Task.detached {
             do {
+                let peers = await self.peers()
+                let client: ScaffoldingClient = .init(
+                    easyTier: EasyTierManager.shared.makeEasyTier(peers: peers),
+                    playerInfo: self.playerInfo()
+                )
+                
                 try await client.connect(to: roomCode, terminationHandler: { [weak self] process in
                     guard let self else { return }
                     Task { @MainActor in
@@ -251,6 +256,29 @@ class MultiplayerViewModel: ObservableObject {
             name: AccountViewModel().currentAccount?.profile.name ?? "Anonymous",
             vendor: vendor
         )
+    }
+    
+    private func fetchPeers() async throws -> [String] {
+        var peers: [String] = try await CLAPIClient.shared.getEasyTierPeers()
+        
+        if let customPeer = LauncherConfig.shared.multiplayerCustomPeer {
+            peers.append(customPeer)
+        }
+        return peers
+    }
+    
+    private func peers() async -> [String] {
+        if let peers { return peers }
+        do {
+            let peers = try await fetchPeers()
+            self.peers = peers
+            return peers
+        } catch {
+            err("拉取节点列表失败：\(error.localizedDescription)")
+            hint("拉取节点列表失败：“\(error.localizedDescription)”，联机可能会失败！", type: .critical)
+            self.peers = []
+            return []
+        }
     }
     
     public enum State: Equatable {

--- a/PCL.Mac/ViewModels/MultiplayerViewModel.swift
+++ b/PCL.Mac/ViewModels/MultiplayerViewModel.swift
@@ -20,7 +20,7 @@ class MultiplayerViewModel: ObservableObject {
     private var server: ScaffoldingServer?
     private var client: ScaffoldingClient?
     private var serverCheckTask: Task<Void, Swift.Error>?
-    private var peers: [String]?
+    @MainActor private var peers: [String]?
     private let vendor: String = "PCL.Mac \(Metadata.appVersion), SwiftScaffolding 0.2.1, EasyTier v2.5.0"
     
     /// 创建并启动一个 Scaffolding 联机中心。
@@ -267,6 +267,7 @@ class MultiplayerViewModel: ObservableObject {
         return peers
     }
     
+    @MainActor
     private func peers() async -> [String] {
         if let peers { return peers }
         do {
@@ -276,7 +277,6 @@ class MultiplayerViewModel: ObservableObject {
         } catch {
             err("拉取节点列表失败：\(error.localizedDescription)")
             hint("拉取节点列表失败：“\(error.localizedDescription)”，联机可能会失败！", type: .critical)
-            self.peers = []
             return []
         }
     }

--- a/PCL.Mac/Views/Multiplayer/MultiplayerPage.swift
+++ b/PCL.Mac/Views/Multiplayer/MultiplayerPage.swift
@@ -49,7 +49,11 @@ struct MultiplayerPage: View {
         }
         .task {
             if viewModel.easyTierStatus == nil {
-                _ = try? await viewModel.fetchEasyTierStatus()
+                do {
+                    _ = try await viewModel.fetchEasyTierStatus()
+                } catch {
+                    err("获取 EasyTier 状态失败：\(error.localizedDescription)")
+                }
             }
         }
         .onChange(of: viewModel.state) { newValue in

--- a/PCL.Mac/Views/Multiplayer/MultiplayerSettingsPage.swift
+++ b/PCL.Mac/Views/Multiplayer/MultiplayerSettingsPage.swift
@@ -8,18 +8,9 @@
 import SwiftUI
 
 struct MultiplayerSettingsPage: View {
-    @State private var customPeer: String = LauncherConfig.shared.multiplayerCustomPeer ?? ""
-    
     var body: some View {
         CardContainer {
             MyCard("EasyTier 设置", foldable: false) {
-                configLine(label: "自定义节点") {
-                    MyTextField(text: $customPeer)
-                        .onChange(of: customPeer) { newValue in
-                            LauncherConfig.shared.multiplayerCustomPeer = newValue
-                        }
-                }
-                
                 HStack {
                     MyButton("删除 EasyTier", type: .red) {
                         EasyTierManager.shared.delete()
@@ -29,22 +20,7 @@ struct MultiplayerSettingsPage: View {
                     Spacer()
                 }
                 .frame(height: 35)
-                .padding(.top, 12)
             }
         }
-    }
-    
-    @ViewBuilder
-    private func configLine(label: String,  @ViewBuilder body: () -> some View) -> some View {
-        HStack(spacing: 20) {
-            MyText(label)
-                .frame(width: 120, alignment: .leading)
-            HStack {
-                Spacer(minLength: 0)
-                body()
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .padding(.horizontal, 6)
     }
 }


### PR DESCRIPTION
本 PR 使启动器不再硬编码 EasyTier 节点列表，改为通过 `https://api.cylorine.studio/easytier/peers` 获取。