### PR TITLE
fix: selectedVersionGroup 会在资源类型不为模组时附带 modLoader

### DIFF
--- a/PCL.Mac/ViewModels/ResourceInstallViewModel.swift
+++ b/PCL.Mac/ViewModels/ResourceInstallViewModel.swift
@@ -29,6 +29,10 @@ class ResourceInstallViewModel: ObservableObject {
         let selectedVersionType: MinecraftVersion.VersionType? = (selectedInstance?.version).flatMap { CoreState.versionManifest.version(for: $0.id) }?.type
         var selectedVersionGroup: VersionGroup? = selectedInstanceKey.map { ($0, []) }
         
+        if let selected = selectedVersionGroup, project.type != .mod {
+            selectedVersionGroup?.0 = .init(loader: nil, version: selected.0.version)
+        }
+        
         let versions: [ModrinthVersion] = try await ModrinthAPIClient.shared.versions(ofProject: project.id, revalidate: true)
         
         var versionMap: [VersionMapKey: [ProjectVersionModel]] = [:]


### PR DESCRIPTION
| 修复前 | 修复后 |
|-|-|
| <img width="432" height="234" alt="image" src="https://github.com/user-attachments/assets/990b30ff-960d-4b7d-9413-396a53d3ab33" /> | <img width="376" height="236" alt="image" src="https://github.com/user-attachments/assets/e71e44a4-2313-4d3b-9ff9-bc973ba812a0" /> |
