### PR TITLE
feat: retry failed single file downloads

### DIFF
--- a/PCL.Mac.Core/Utils/Download/MultiFileDownloader.swift
+++ b/PCL.Mac.Core/Utils/Download/MultiFileDownloader.swift
@@ -11,6 +11,7 @@ public class MultiFileDownloader {
     private let items: [DownloadItem]
     private let concurrentLimit: Int
     private let replaceMethod: ReplaceMethod
+    private let maxRetryCount: Int
     private let progressHandler: (@MainActor (Double) -> Void)?
     private var progress: [UUID: Double] = [:]
     
@@ -18,11 +19,13 @@ public class MultiFileDownloader {
         items: [DownloadItem],
         concurrentLimit: Int,
         replaceMethod: ReplaceMethod,
+        maxRetryCount: Int = 2,
         progressHandler: (@MainActor (Double) -> Void)? = nil
     ) {
         self.items = items
         self.concurrentLimit = concurrentLimit
         self.replaceMethod = replaceMethod
+        self.maxRetryCount = maxRetryCount
         self.progressHandler = progressHandler
     }
     
@@ -87,7 +90,7 @@ public class MultiFileDownloader {
         await MainActor.run {
             progress[uuid] = 0
         }
-        try await SingleFileDownloader.download(item, replaceMethod: replaceMethod) { progress in
+        try await SingleFileDownloader.download(item, replaceMethod: replaceMethod, maxRetryCount: maxRetryCount) { progress in
             self.progress[uuid] = progress
         }
     }

--- a/PCL.Mac.Core/Utils/Download/SingleFileDownloader.swift
+++ b/PCL.Mac.Core/Utils/Download/SingleFileDownloader.swift
@@ -65,21 +65,33 @@ public enum SingleFileDownloader {
         request.cachePolicy = .reloadIgnoringLocalAndRemoteCacheData
         request.setValue("PCL-Mac/\(Metadata.appVersion)", forHTTPHeaderField: "User-Agent")
         
-        let task: URLSessionDownloadTask = session.downloadTask(with: request)
-        try await withTaskCancellationHandler {
-            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-                DownloadDelegate.shared.register(task: task, destination: destination, continuation: continuation, progressHandler: progressHandler)
-                task.resume()
-            }
-        } onCancel: {
-            task.cancel()
-        }
-        
-        // 验证 checksums
-        if let checksums {
-            guard try FileUtils.checkFile(at: destination, with: checksums) == true else {
-                try FileManager.default.removeItem(at: destination)
-                throw DownloadError.checksumMismatch
+        var retryCount: Int = 0
+        while true {
+            let task: URLSessionDownloadTask = session.downloadTask(with: request)
+            do {
+                try await withTaskCancellationHandler {
+                    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                        DownloadDelegate.shared.register(task: task, destination: destination, continuation: continuation, progressHandler: progressHandler)
+                        task.resume()
+                    }
+                } onCancel: {
+                    task.cancel()
+                }
+
+                // 验证 checksums
+                if let checksums {
+                    guard try FileUtils.checkFile(at: destination, with: checksums) == true else {
+                        try FileManager.default.removeItem(at: destination)
+                        throw DownloadError.checksumMismatch
+                    }
+                }
+                break
+            } catch {
+                if error.isCancellationError { throw CancellationError() }
+                try? FileManager.default.removeItem(at: destination)
+                guard retryCount < 2 else { throw error }
+                retryCount += 1
+                try await Task.sleep(nanoseconds: UInt64(retryCount) * 500_000_000)
             }
         }
         if executable {
@@ -87,4 +99,3 @@ public enum SingleFileDownloader {
         }
     }
 }
-

--- a/PCL.Mac.Core/Utils/Download/SingleFileDownloader.swift
+++ b/PCL.Mac.Core/Utils/Download/SingleFileDownloader.swift
@@ -11,8 +11,8 @@ import Foundation
 public enum SingleFileDownloader {
     public static let session: URLSession = .init(configuration: .default, delegate: DownloadDelegate.shared, delegateQueue: DownloadDelegate.queue)
     
-    public static func download(_ item: DownloadItem, replaceMethod: ReplaceMethod, progressHandler: (@MainActor (Double) -> Void)? = nil) async throws {
-        try await download(url: item.url, destination: item.destination, checksums: item.checksums, executable: item.executable, replaceMethod: replaceMethod, progressHandler: progressHandler)
+    public static func download(_ item: DownloadItem, replaceMethod: ReplaceMethod, maxRetryCount: Int = 2, progressHandler: (@MainActor (Double) -> Void)? = nil) async throws {
+        try await download(url: item.url, destination: item.destination, checksums: item.checksums, executable: item.executable, replaceMethod: replaceMethod, maxRetryCount: maxRetryCount, progressHandler: progressHandler)
     }
     
     public static func download(
@@ -21,6 +21,7 @@ public enum SingleFileDownloader {
         sha1: String?,
         executable: Bool = false,
         replaceMethod: ReplaceMethod,
+        maxRetryCount: Int = 2,
         progressHandler: (@MainActor (Double) -> Void)? = nil
     ) async throws {
         try await download(
@@ -29,6 +30,7 @@ public enum SingleFileDownloader {
             checksums: sha1.map { ["sha1": $0] } ?? [:],
             executable: executable,
             replaceMethod: replaceMethod,
+            maxRetryCount: maxRetryCount,
             progressHandler: progressHandler
         )
     }
@@ -39,6 +41,7 @@ public enum SingleFileDownloader {
         checksums: [String: String]?,
         executable: Bool = false,
         replaceMethod: ReplaceMethod,
+        maxRetryCount: Int = 2,
         progressHandler: (@MainActor (Double) -> Void)? = nil
     ) async throws {
         // 文件已存在处理
@@ -77,21 +80,21 @@ public enum SingleFileDownloader {
                 } onCancel: {
                     task.cancel()
                 }
-
-                // 验证 checksums
-                if let checksums {
-                    guard try FileUtils.checkFile(at: destination, with: checksums) == true else {
-                        try FileManager.default.removeItem(at: destination)
-                        throw DownloadError.checksumMismatch
-                    }
-                }
                 break
             } catch {
                 if error.isCancellationError { throw CancellationError() }
                 try? FileManager.default.removeItem(at: destination)
-                guard retryCount < 2 else { throw error }
+                guard retryCount < maxRetryCount else { throw error }
                 retryCount += 1
-                try await Task.sleep(nanoseconds: UInt64(retryCount) * 500_000_000)
+                try await Task.sleep(seconds: Double(retryCount) * 0.5)
+            }
+        }
+
+        // 验证 checksums
+        if let checksums {
+            guard try FileUtils.checkFile(at: destination, with: checksums) == true else {
+                try FileManager.default.removeItem(at: destination)
+                throw DownloadError.checksumMismatch
             }
         }
         if executable {


### PR DESCRIPTION
## Summary
- Add retry behavior to single file downloads.
- Retry failed download attempts up to `maxRetryCount` times, defaulting to 2 retries.
- Expose `maxRetryCount` on `MultiFileDownloader` and pass it through to the underlying single-file downloads.
- Preserve cancellation behavior so cancelled downloads are not retried.
- Keep checksum validation outside the retry loop after a download attempt succeeds.

Refs #192

## Notes
This PR covers download retry for `SingleFileDownloader` and exposes the same retry count control through `MultiFileDownloader`. Request-level retry is intentionally left out for now based on maintainer feedback.

## Testing
- Passed: temporary local retry verification using an HTTP server that returned `500`, `500`, then `200`; confirmed the downloader made 3 requests and completed with the expected file content.
- Passed: `xcodebuild test -project PCL.Mac.xcodeproj -scheme PCL.Mac -destination 'platform=macOS,arch=arm64' -only-testing:PCL.Mac.Tests/DownloadTests -parallel-testing-enabled NO -resultBundlePath /tmp/PCLMacDownloadTestsBeforeMultiRetryPush.xcresult COMPILER_INDEX_STORE_ENABLE=NO`
- Passed: `git diff --check`
