### PR TITLE
fix: PlayerProfile.Property 会在值不为 base64 时 decode 失败

### DIFF
--- a/PCL.Mac.Core/Models/PlayerProfile.swift
+++ b/PCL.Mac.Core/Models/PlayerProfile.swift
@@ -18,7 +18,7 @@ public struct PlayerProfile: Codable {
         self.properties = properties
     }
     
-    public func property(forName name: String) -> Data? {
+    public func property(forName name: String) -> String? {
         return properties.first(where: { $0.name == name })?.value
     }
     
@@ -45,6 +45,6 @@ public struct PlayerProfile: Codable {
     public struct Property: Codable {
         public let name: String
         public let signature: String?
-        public let value: Data
+        public let value: String
     }
 }

--- a/PCL.Mac/ViewModels/AccountViewModel.swift
+++ b/PCL.Mac/ViewModels/AccountViewModel.swift
@@ -85,7 +85,8 @@ class AccountViewModel: ObservableObject {
     public func skinData(for account: Account) async -> Data {
         let defaultSkin: Data = .init(base64Encoded: "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAMAAACdt4HsAAAAdVBMVEUAAAAKvLwAzMwmGgokGAgrHg0zJBE/KhW3g2uzeV5SPYn///+qclmbY0mQWT8Af38AaGhVVVWUYD52SzOBUzmPXj5JJRBCHQp3QjVqQDA0JRIoKCg3Nzc/Pz9KSko6MYlBNZtGOqUDenoFiIgElZUApKQAr6/wvakZAAAAAXRSTlMAQObYZgAAAolJREFUeNrt1l1rHucZReFrj/whu5hSCCQtlOTE/f+/Jz4q9Cu0YIhLcFVpVg+FsOCVehi8jmZgWOzZz33DM4CXlum3gH95GgeAzQZVeL4gTm6Cbp4vqFkD8HwBazPY8wWbMq9utu3mNZ5fotVezbzOE3kBEFbaZuc8kb00NTMUbWJp678Xf2GV7RRtx1TDQQ6XBNvsmL2+2vHq1TftmMPIyAWujtN2cl274ua2jpVpZneXEjjo7XW1q53V9ds4ODO5xIuhvGHvfLI3aixauig415uuO2+vl9+cncfsFw25zL650fXn687jqnXuP68/X3+eV3zE7y6u9eB73MlfAcfbTf3yR8CfAX+if8S/H5/EAbAxj5LN48tULvEBOh8V1AageMTXe2YHAOwHbZxrzPkSR3+ffr8TR2JDzE/4Fj8CDgEwDsW+q+9GsR07hhg2CsALBgMo2v5wNxXnQXMeGQVW7gUAyKI2m6KDsJ8Au3++F5RZO+kKNQjQcLLWgjwUjBXLltFgWWMUUlviocBgNoxNGgMjSxiYAA7zgLFo2hgIENiDU8gQCzDOmViGFAsEuBcQSDCothhpJaDRA8E5fHqH2nTbYm5fHLo1V0u3B7DAuheoeScRYabjjjuzs17cHVaTrTXmK78m9swP34d9oK/dfeXSIH2PW/MXwPvxN/bJlxw8zlYAcEyeI6gNgA/O8P8neN8xe1IHP2gTzegjvhUDfuRygmwEs2GE4mkCDIAzm2R4yAuPsIdR9k8AvMc+3L9+2UEjo4WP0FpgP19O0MzCsqxIoMsdDBvYcQyGmO0ZJRoYCKjLJWY0BAhYwGUBCgkh8MRdOKt+ruqMwAB2OcEX94U1TPbYJP0PkyyAI1S6cSIAAAAASUVORK5CYII=")!
         do {
-            guard let textures: Data = account.profile.property(forName: "textures") else {
+            guard let textures: Data = account.profile.property(forName: "textures")
+                .flatMap({ Data(base64Encoded: $0) }) else {
                 return defaultSkin
             }
             let json: JSON = try .init(data: textures)


### PR DESCRIPTION
本 PR 将 `Property.value` 的类型修改为 `String`，因为它不一定是 base64 编码的 `Data`。