### PR TITLE
chore: 在加载客户端清单时对 `libraries` 进行去重

### DIFF
--- a/PCL.Mac.Core/Models/ClientManifest.swift
+++ b/PCL.Mac.Core/Models/ClientManifest.swift
@@ -89,7 +89,14 @@ public class ClientManifest: Decodable {
         self.downloads = try container.decodeIfPresent(Downloads.self, forKey: .downloads)
         self.id = try container.decode(String.self, forKey: .id)
         self.javaVersion = try container.decodeIfPresent(JavaVersion.self, forKey: .javaVersion) ?? .init(component: "jre-legacy", majorVersion: 8)
-        self.libraries = try container.decode([Library].self, forKey: .libraries)
+        
+        let libraries = try container.decode([Library].self, forKey: .libraries)
+        var librarySet: Set<HashableLibrary> = []
+        self.libraries = libraries.lazy.reversed()
+            .filter { librarySet.insert(.init(from: $0)).inserted }
+            .reversed()
+        librarySet.removeAll()
+        
         self.logging = (try? container.decodeIfPresent(Logging.self, forKey: .logging)) ?? .init(
             argument: "-Dlog4j.configurationFile=${path}",
             file: .init(

--- a/PCL.Mac.Core/Models/ClientManifest.swift
+++ b/PCL.Mac.Core/Models/ClientManifest.swift
@@ -87,13 +87,18 @@ public class ClientManifest: Decodable {
         }
         self.assetIndex = try container.decodeIfPresent(AssetIndex.self, forKey: .assetIndex)
         self.downloads = try container.decodeIfPresent(Downloads.self, forKey: .downloads)
-        self.id = try container.decode(String.self, forKey: .id)
+        let id = try container.decode(String.self, forKey: .id)
+        self.id = id
         self.javaVersion = try container.decodeIfPresent(JavaVersion.self, forKey: .javaVersion) ?? .init(component: "jre-legacy", majorVersion: 8)
         
         let libraries = try container.decode([Library].self, forKey: .libraries)
         var librarySet: Set<HashableLibrary> = []
         self.libraries = libraries.lazy.reversed()
-            .filter { librarySet.insert(.init(from: $0)).inserted }
+            .filter {
+                let inserted = librarySet.insert(.init(from: $0)).inserted
+                if !inserted { debug("已去除 \(id) 中的重复 library \($0.name)") }
+                return inserted
+            }
             .reversed()
         librarySet.removeAll()
         
@@ -276,7 +281,7 @@ public class ClientManifest: Decodable {
         }
     }
     
-    public class Rule: Decodable {
+    public class Rule: Decodable, Hashable, Equatable {
         public let allow: Bool
         public let osName: String?
         public let osArch: Architecture?
@@ -299,6 +304,16 @@ public class ClientManifest: Decodable {
             if let osName, osName != "osx" { return !allow }
             if let osArch, osArch != .systemArchitecture() { return !allow }
             return allow
+        }
+        
+        public func hash(into hasher: inout Hasher) {
+            hasher.combine(allow)
+            hasher.combine(osName)
+            hasher.combine(osArch)
+        }
+        
+        public static func == (lhs: Rule, rhs: Rule) -> Bool {
+            lhs.allow == rhs.allow && lhs.osName == rhs.osName && lhs.osArch == rhs.osArch
         }
     }
     
@@ -398,12 +413,14 @@ public extension ClientManifest {
         private let artifactId: String
         private let classifier: String?
         private let isNativesLibrary: Bool
+        private let rules: [Rule]
         
         public init(from library: Library) {
             self.groupId = library.groupId
             self.artifactId = library.artifactId
             self.classifier = library.classifier
             self.isNativesLibrary = library.isNativesLibrary
+            self.rules = library.rules
         }
     }
 }


### PR DESCRIPTION
部分由 PCL 安装的、带有模组加载器的实例 的 客户端清单 可能会包含重复的依赖库（如 `org.ow2.asm:asm:9.8` 与 `org.ow2.asm:asm:9.6`），本 PR 在加载客户端清单时对它们进行了去重，可以解决一些崩溃问题。