### PR TITLE
fix: ModrinthAPIClient 无法处理 404 响应

### DIFF
--- a/PCL.Mac.Core/Services/ModrinthAPIClient.swift
+++ b/PCL.Mac.Core/Services/ModrinthAPIClient.swift
@@ -53,9 +53,11 @@ public class ModrinthAPIClient {
     /// - Parameters:
     ///   - slug: 指定 id 或 slug。
     ///   - revalidate: 是否验证本地缓存有效性。
-    /// - Returns: 对应的 `ModrinthProject`。
-    public func project(_ slug: String, revalidate: Bool = false) async throws -> ModrinthProject {
-        return try await HTTPClient.shared.get(apiRoot.appending(path: "/v2/project/\(slug)"), revalidate: revalidate).decode(ModrinthProject.self)
+    /// - Returns: 对应的 `ModrinthProject`，不存在时返回 `nil`。
+    public func project(_ slug: String, revalidate: Bool = false) async throws -> ModrinthProject? {
+        let response = try await HTTPClient.shared.get(apiRoot.appending(path: "/v2/project/\(slug)"), revalidate: revalidate)
+        if response.statusCode == 404 { return nil }
+        return try response.decode(ModrinthProject.self)
     }
     
     /// 批量获取指定 id 或 slug 对应的 `ModrinthProject`
@@ -92,9 +94,11 @@ public class ModrinthAPIClient {
     
     /// 获取指定 id 对应的 `ModrinthVersion`。
     /// - Parameter slug: 指定 id。
-    /// - Returns: 对应的 `ModrinthVersion`。
-    public func version(_ id: String) async throws -> ModrinthVersion {
-        return try await HTTPClient.shared.get(apiRoot.appending(path: "/v2/version/\(id)")).decode(ModrinthVersion.self)
+    /// - Returns: 对应的 `ModrinthVersion`，不存在时返回 `nil`。
+    public func version(_ id: String) async throws -> ModrinthVersion? {
+        let response = try await HTTPClient.shared.get(apiRoot.appending(path: "/v2/version/\(id)"))
+        if response.statusCode == 404 { return nil }
+        return try response.decode(ModrinthVersion.self)
     }
     
     /// 根据文件的 SHA-1 哈希值查询 `ModrinthVersion`。

--- a/PCL.Mac.Core/Services/Resource/ResourceRemoteLookupService.swift
+++ b/PCL.Mac.Core/Services/Resource/ResourceRemoteLookupService.swift
@@ -18,8 +18,8 @@ public class ResourceRemoteLookupService {
     
     /// 根据 SHA-1 哈希值查询单个资源。
     public func lookup(hash: String) async throws -> RemoteResourceInfo? {
-        if let modrinthVersion = try await modrinthClient.version(ofHash: hash) {
-            let project = try await modrinthClient.project(modrinthVersion.projectId, revalidate: true)
+        if let modrinthVersion = try await modrinthClient.version(ofHash: hash),
+           let project = try await modrinthClient.project(modrinthVersion.projectId, revalidate: true) {
             return RemoteResourceInfo(project, version: modrinthVersion)
         }
         

--- a/PCL.Mac.Tests/Services/ModrinthAPIClientTests.swift
+++ b/PCL.Mac.Tests/Services/ModrinthAPIClientTests.swift
@@ -20,10 +20,10 @@ struct ModrinthAPIClientTests {
         _ = try await ModrinthAPIClient.shared.search(type: .mod, "Fabric API", forVersion: "1.21.11")
         _ = try await ModrinthAPIClient.shared.search(type: .mod, "", forVersion: nil)
         
-        let sodium: ModrinthProject = try await ModrinthAPIClient.shared.project("sodium")
+        let sodium: ModrinthProject = try await ModrinthAPIClient.shared.project("sodium").unwrap()
         print(sodium)
         _ = try await ModrinthAPIClient.shared.versions(ofProject: sodium)
-        let version: ModrinthVersion = try await ModrinthAPIClient.shared.version(sodium.versions![0])
+        let version: ModrinthVersion = try await ModrinthAPIClient.shared.version(sodium.versions![0]).unwrap()
         print(version)
         
         let hashes: [String] = [

--- a/PCL.Mac/ViewModels/Instance/InstalledResourcesViewModel.swift
+++ b/PCL.Mac/ViewModels/Instance/InstalledResourcesViewModel.swift
@@ -133,7 +133,10 @@ class InstalledResourcesViewModel: ObservableObject {
         for source in resource.sources {
             if case .modrinth(let projectId) = source {
                 do {
-                    let project = try await ModrinthAPIClient.shared.project(projectId)
+                    guard let project = try await ModrinthAPIClient.shared.project(projectId) else {
+                        warn("记录了 \(resource.fileName) 对应的 Modrinth projectId（\(projectId)），但它在 Modrinth 上已不存在")
+                        return nil
+                    }
                     return .init(project)
                 } catch {
                     throw SimpleError("查询 Modrinth Project 失败：\(error.localizedDescription)")

--- a/PCL.Mac/ViewModels/ResourceInstallViewModel.swift
+++ b/PCL.Mac/ViewModels/ResourceInstallViewModel.swift
@@ -43,8 +43,12 @@ class ResourceInstallViewModel: ObservableObject {
                       dependency.isRequired else {
                     continue
                 }
-                let project: ModrinthProject = try await ModrinthAPIClient.shared.project(projectId)
-                dependencies.append(.init(versionId: dependency.id, projectId: projectId, project: .init(project)))
+                if let project = try await ModrinthAPIClient.shared.project(projectId) {
+                    dependencies.append(.init(versionId: dependency.id, projectId: projectId, project: .init(project)))
+                } else {
+                    warn("依赖 \(projectId) 在 Modrinth 上已不存在")
+                    debug(version)
+                }
             }
             
             var keys: [VersionMapKey] = []


### PR DESCRIPTION
本 PR 将 `ModrinthAPIClient.project(_:)` 和 `version(_:)` 的返回值类型改为 `Optional`，并在响应状态码为 404 时返回 `nil`。

修复了某些包含已被移除的依赖项的资源版本列表加载失败的问题（如 [RenderScale](https://modrinth.com/mod/renderscale/version/1.4.0-alpha.4-neoforge+1.21.11)）。