### PR TITLE
fix: .gitignore 未正确忽略 `__MACOSX` 归档元数据目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # macOS
 .DS_Store
-_MACOSX
 ._*
+__MACOSX/
 
 # Xcode
-PCL.Mac.xcodeproj/xcuserdata
-PCL.Mac.xcodeproj/project.xcworkspace/xcuserdata
+PCL.Mac.xcodeproj/xcuserdata/
+PCL.Mac.xcodeproj/project.xcworkspace/xcuserdata/


### PR DESCRIPTION
`_MACOSX` → `__MACOSX/`