### PR TITLE
fix: 低版本 Forge 可能因为安装器 URL 格式问题安装失败

### DIFF
--- a/PCL.Mac.Core/Services/Download/DownloadItem.swift
+++ b/PCL.Mac.Core/Services/Download/DownloadItem.swift
@@ -13,7 +13,13 @@ public struct DownloadItem: Hashable {
     public let checksums: [String: String]?
     public let executable: Bool
     
+    public var url: URL { urls.first! }
+    
     public init(urls: [URL], destination: URL, checksums: [String: String]?, executable: Bool = false) {
+        guard !urls.isEmpty else {
+            preconditionFailure("At least one URL must be provided for download.")
+        }
+        
         self.urls = urls
         self.destination = destination
         self.checksums = checksums

--- a/PCL.Mac.Core/Services/Download/DownloadItem.swift
+++ b/PCL.Mac.Core/Services/Download/DownloadItem.swift
@@ -8,21 +8,30 @@
 import Foundation
 
 public struct DownloadItem: Hashable {
-    public let url: URL
+    public let urls: [URL]
     public let destination: URL
     public let checksums: [String: String]?
     public let executable: Bool
     
-    public init(url: URL, destination: URL, checksums: [String: String]?, executable: Bool = false) {
-        self.url = url
+    public init(urls: [URL], destination: URL, checksums: [String: String]?, executable: Bool = false) {
+        self.urls = urls
         self.destination = destination
         self.checksums = checksums
         self.executable = executable
     }
     
+    public init(url: URL, destination: URL, checksums: [String: String]?, executable: Bool = false) {
+        self.init(
+            urls: [url],
+            destination: destination,
+            checksums: checksums,
+            executable: executable
+        )
+    }
+    
     public init(url: URL, destination: URL, sha1: String?, executable: Bool = false) {
         self.init(
-            url: url,
+            urls: [url],
             destination: destination,
             checksums: sha1.map { ["sha1": $0] },
             executable: executable

--- a/PCL.Mac.Core/Services/Download/FileDownloader.swift
+++ b/PCL.Mac.Core/Services/Download/FileDownloader.swift
@@ -48,7 +48,12 @@ public class FileDownloader {
 
         try FileManager.default.createDirectory(at: file.destination.deletingLastPathComponent(), withIntermediateDirectories: true)
 
-        let candidates = sourceManager.orderedCandidates(for: file.url, preferMirror: preferMirror)
+        let candidates = file.urls.flatMap { sourceManager.orderedCandidates(for: $0, preferMirror: preferMirror) }
+        if candidates.isEmpty {
+            err("\(file.destination.lastPathComponent) 的候选列表为空")
+            throw DownloadError.unknownError
+        }
+        
         var lastError: Error?
 
         for candidate in candidates {

--- a/PCL.Mac.Core/Services/ForgeInstallService.swift
+++ b/PCL.Mac.Core/Services/ForgeInstallService.swift
@@ -91,8 +91,13 @@ public class ForgeInstallService {
     /// 下载安装器本体并解析。
     /// - Returns: 是否是新版本安装器，且需要继续执行后续步骤。
     private func downloadInstaller(progressHandler: @MainActor @escaping (Double) -> Void) async throws -> Bool {
-        let destination: URL = tempDirectory.appending(path: "installer.jar")
-        try await FileDownloader.shared.download(url: installerDownloadURL(), destination: destination, progressHandler: progressHandler)
+        let destination = tempDirectory.appending(path: "installer.jar")
+        let item = DownloadItem(
+            urls: installerDownloadURLs(),
+            destination: destination,
+            checksums: nil
+        )
+        try await FileDownloader.shared.download(item, progressHandler: progressHandler)
         _ = try FileManager.default.unzipItem(at: destination, to: installerURL)
         
         // 处理客户端清单
@@ -127,12 +132,14 @@ public class ForgeInstallService {
         }
     }
     
-    internal func installerDownloadURL() -> URL {
-        let path = version.compare("11.14.0.1296", options: .numeric) != .orderedAscending
-        ? "net/minecraftforge/forge/\(minecraftVersion)-\(version)/forge-\(minecraftVersion)-\(version)-installer.jar"
-        : "net/minecraftforge/forge/\(minecraftVersion)-\(version)-\(minecraftVersion)/forge-\(minecraftVersion)-\(version)-\(minecraftVersion)-installer.jar"
+    internal func installerDownloadURLs() -> [URL] {
+        let root = URL(string: "https://files.minecraftforge.net/maven")!
+        let paths = [
+            "net/minecraftforge/forge/\(minecraftVersion)-\(version)/forge-\(minecraftVersion)-\(version)-installer.jar",
+            "net/minecraftforge/forge/\(minecraftVersion)-\(version)-\(minecraftVersion)/forge-\(minecraftVersion)-\(version)-\(minecraftVersion)-installer.jar"
+        ]
         
-        return .init(string: "https://files.minecraftforge.net/maven")!.appending(path: path)
+        return paths.map(root.appending(path:))
     }
     
     private func makeValueDict() -> [String: String] {

--- a/PCL.Mac.Core/Services/NeoforgeInstallService.swift
+++ b/PCL.Mac.Core/Services/NeoforgeInstallService.swift
@@ -8,11 +8,13 @@
 import Foundation
 
 public class NeoforgeInstallService: ForgeInstallService {
-    override func installerDownloadURL() -> URL {
+    override func installerDownloadURLs() -> [URL] {
+        let root = URL(string: "https://maven.neoforged.net/releases")!
+        
         if minecraftVersion.id == "1.20.1" {
-            let version: String = !self.version.hasPrefix("1.20.1-") ? "1.20.1-\(self.version)" : self.version
-            return .init(string: "https://maven.neoforged.net/releases/net/neoforged/forge/\(version)/forge-\(version)-installer.jar")!
+            let version = !self.version.hasPrefix("1.20.1-") ? "1.20.1-\(self.version)" : self.version
+            return [root.appending(path: "net/neoforged/forge/\(version)/forge-\(version)-installer.jar")]
         }
-        return .init(string: "https://maven.neoforged.net/releases/net/neoforged/neoforge/\(version)/neoforge-\(version)-installer.jar")!
+        return [root.appending(path: "net/neoforged/neoforge/\(version)/neoforge-\(version)-installer.jar")]
     }
 }


### PR DESCRIPTION
允许为单个 `DownloadItem` 设置多个候选 `URL`，并在 Forge 安装时指定两种格式的安装器 URL，以解决低版本 Forge 安装失败的问题。

closes #222 