### PR TITLE
feat: 支持自定义 JVM 启动参数，修复 SDKMAN 等工具安装的 Java 搜索不到

### DIFF
--- a/PCL.Mac.Core/Extensions/String+Arguments.swift
+++ b/PCL.Mac.Core/Extensions/String+Arguments.swift
@@ -1,0 +1,31 @@
+//
+//  String+Arguments.swift
+//  PCL.Mac
+//
+//  Created by yuanmu on 2026/8/9.
+//
+
+public extension String {
+    /// 将一行命令行参数按空白字符拆分为参数数组。
+    func splitToArguments() -> [String] {
+        var arguments: [String] = []
+        var current: String?
+        var quote: Character?
+
+        for character in self {
+            if character == quote {
+                quote = nil
+            } else if quote == nil, character == "\"" || character == "'" {
+                quote = character
+                current = current ?? ""
+            } else if quote == nil, character.isWhitespace {
+                if let current { arguments.append(current) }
+                current = nil
+            } else {
+                current = (current ?? "") + String(character)
+            }
+        }
+        if let current { arguments.append(current) }
+        return arguments
+    }
+}

--- a/PCL.Mac.Core/Extensions/String+Arguments.swift
+++ b/PCL.Mac.Core/Extensions/String+Arguments.swift
@@ -10,6 +10,7 @@ public extension String {
     func splitToArguments() -> [String] {
         var arguments: [String] = []
         var current: String?
+        var quote: Character?
         var escaping = false
 
         for character in self {
@@ -34,5 +35,23 @@ public extension String {
         if escaping { current = (current ?? "") + "\\" }
         if let current { arguments.append(current) }
         return arguments
+    }
+}
+
+public extension [String] {
+    /// `splitToArguments()` 的逆操作：将参数数组拼回一行字符串。
+    ///
+    /// 含空白字符或单引号的参数会以双引号包裹，参数中的 `\` 与 `"` 会被转义，保证拼接结果重新拆分后与原数组一致。
+    func joinedToArgumentLine() -> String {
+        map { argument in
+            let escaped: String = argument
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
+            if argument.isEmpty || argument.contains(where: \.isWhitespace) || argument.contains("'") {
+                return "\"\(escaped)\""
+            }
+            return escaped
+        }
+        .joined(separator: " ")
     }
 }

--- a/PCL.Mac.Core/Extensions/String+Arguments.swift
+++ b/PCL.Mac.Core/Extensions/String+Arguments.swift
@@ -10,10 +10,16 @@ public extension String {
     func splitToArguments() -> [String] {
         var arguments: [String] = []
         var current: String?
-        var quote: Character?
+        var escaping = false
 
         for character in self {
-            if character == quote {
+            if escaping {
+                current = (current ?? "") + String(character)
+                escaping = false
+            } else if character == "\\", quote != "'" {
+                escaping = true
+                current = current ?? ""
+            } else if character == quote {
                 quote = nil
             } else if quote == nil, character == "\"" || character == "'" {
                 quote = character
@@ -25,6 +31,7 @@ public extension String {
                 current = (current ?? "") + String(character)
             }
         }
+        if escaping { current = (current ?? "") + "\\" }
         if let current { arguments.append(current) }
         return arguments
     }

--- a/PCL.Mac.Core/Minecraft/Launch/LaunchOptions.swift
+++ b/PCL.Mac.Core/Minecraft/Launch/LaunchOptions.swift
@@ -15,6 +15,7 @@ public struct LaunchOptions {
     public var manifest: ClientManifest!
     public var repository: MinecraftRepository!
     public var memory: UInt64 = 4096
+    public var extraJvmArguments: [String] = []
     public var demo: Bool = false
     
     // Authlib Injector

--- a/PCL.Mac.Core/Minecraft/Launch/MinecraftLauncher.swift
+++ b/PCL.Mac.Core/Minecraft/Launch/MinecraftLauncher.swift
@@ -53,6 +53,7 @@ public class MinecraftLauncher {
         
         var arguments: [String] = []
         arguments.append("-Xmx\(options.memory)m")
+        arguments.append(contentsOf: options.extraJvmArguments)
         arguments.append(contentsOf: manifest.jvmArguments.flatMap { $0.rules.allSatisfy { $0.test(with: options) } ? $0.value : [] })
         if let authlibInjectorPath = options.authlibInjectorPath,
            let authServerURL = options.authServerURL,

--- a/PCL.Mac.Core/Minecraft/Launch/MinecraftLauncher.swift
+++ b/PCL.Mac.Core/Minecraft/Launch/MinecraftLauncher.swift
@@ -53,8 +53,8 @@ public class MinecraftLauncher {
         
         var arguments: [String] = []
         arguments.append("-Xmx\(options.memory)m")
-        arguments.append(contentsOf: options.extraJvmArguments)
         arguments.append(contentsOf: manifest.jvmArguments.flatMap { $0.rules.allSatisfy { $0.test(with: options) } ? $0.value : [] })
+        arguments.append(contentsOf: options.extraJvmArguments)
         if let authlibInjectorPath = options.authlibInjectorPath,
            let authServerURL = options.authServerURL,
            let prefetchedMeta = options.prefetchedMeta {

--- a/PCL.Mac.Core/Models/Minecraft/MinecraftInstance.swift
+++ b/PCL.Mac.Core/Models/Minecraft/MinecraftInstance.swift
@@ -45,7 +45,7 @@ public class MinecraftInstance: Hashable, Identifiable, Equatable {
     public struct Config: Codable {
         public var jvmHeapSize: UInt64
         public var javaURL: URL?
-        public var jvmArguments: String?
+        public var jvmArguments: [String] = ""
 
         public static let `default`: Config = .init(jvmHeapSize: 4096, javaURL: nil)
     }

--- a/PCL.Mac.Core/Models/Minecraft/MinecraftInstance.swift
+++ b/PCL.Mac.Core/Models/Minecraft/MinecraftInstance.swift
@@ -45,9 +45,22 @@ public class MinecraftInstance: Hashable, Identifiable, Equatable {
     public struct Config: Codable {
         public var jvmHeapSize: UInt64
         public var javaURL: URL?
-        public var jvmArguments: [String] = ""
+        public var jvmArguments: [String]
 
         public static let `default`: Config = .init(jvmHeapSize: 4096, javaURL: nil)
+
+        public init(jvmHeapSize: UInt64, javaURL: URL?, jvmArguments: [String] = []) {
+            self.jvmHeapSize = jvmHeapSize
+            self.javaURL = javaURL
+            self.jvmArguments = jvmArguments
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.jvmHeapSize = try container.decode(UInt64.self, forKey: .jvmHeapSize)
+            self.javaURL = try container.decodeIfPresent(URL.self, forKey: .javaURL)
+            self.jvmArguments = try container.decodeIfPresent([String].self, forKey: .jvmArguments) ?? []
+        }
     }
 }
 

--- a/PCL.Mac.Core/Models/Minecraft/MinecraftInstance.swift
+++ b/PCL.Mac.Core/Models/Minecraft/MinecraftInstance.swift
@@ -45,7 +45,8 @@ public class MinecraftInstance: Hashable, Identifiable, Equatable {
     public struct Config: Codable {
         public var jvmHeapSize: UInt64
         public var javaURL: URL?
-        
+        public var jvmArguments: String?
+
         public static let `default`: Config = .init(jvmHeapSize: 4096, javaURL: nil)
     }
 }

--- a/PCL.Mac.Core/Services/JavaSearcher.swift
+++ b/PCL.Mac.Core/Services/JavaSearcher.swift
@@ -9,18 +9,32 @@ import Foundation
 
 public enum JavaSearcher {
     /// 内部可能存在 Java 目录（如 `zulu-21.jdk`）的目录
-    private static let javaDirectories: [URL] = [
-        URL(fileURLWithPath: "/Library/Java/JavaVirtualMachines"),
-        FileManager.default.homeDirectoryForCurrentUser.appending(path: "Library/Java/JavaVirtualMachines")
+    private static let javaDirectories: [URL] = {
+        let homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser
+        return [
+            URL(fileURLWithPath: "/Library/Java/JavaVirtualMachines"),
+            homeDirectory.appending(path: "Library/Java/JavaVirtualMachines"),
+            homeDirectory.appending(path: ".jdks"),                          // IntelliJ IDEA
+            homeDirectory.appending(path: ".sdkman/candidates/java"),        // SDKMAN!
+            homeDirectory.appending(path: ".asdf/installs/java"),            // asdf
+            homeDirectory.appending(path: ".local/share/mise/installs/java"), // mise
+            homeDirectory.appending(path: ".jenv/versions"),                 // jEnv
+            homeDirectory.appending(path: ".jabba/jdk"),                     // Jabba
+            homeDirectory.appending(path: ".gradle/jdks")                    // Gradle 工具链
+        ]
+    }()
+
+    /// Homebrew 的 openjdk 安装目录，分别对应 Apple Silicon 与 Intel。
+    private static let homebrewDirectories: [URL] = [
+        URL(fileURLWithPath: "/opt/homebrew/opt"),
+        URL(fileURLWithPath: "/usr/local/opt")
     ]
-    
+
     /// 搜索当前环境中安装的 Java（不包含 `/usr/bin/java`）。
     /// - Returns: 当前环境中安装的 Java 列表。
     public static func search() throws -> [JavaRuntime] {
         var runtimes: [JavaRuntime] = []
-        let bundles: [URL] = try findJavaBundles()
-        for bundle in bundles {
-            let homeDirectory: URL = bundle.appending(path: "Contents/Home")
+        for homeDirectory in findJavaHomes() {
             do {
                 let runtime: JavaRuntime = try load(from: homeDirectory)
                 runtimes.append(runtime)
@@ -34,17 +48,15 @@ public enum JavaSearcher {
     
     /// 加载磁盘上的 `JavaRuntime`。
     ///
-    /// - Parameter url: 运行时的 `URL`，包含 `Home` 目录即可。
+    /// - Parameter url: 运行时的 `URL`，位于 Java 主目录内即可（如 `bin/java`）。
     public static func load(from url: URL) throws -> JavaRuntime {
+        // 逐级向上寻找含 release 文件的主目录，以兼容 macOS 的 .jdk 包与 SDKMAN 等工具直接解压的 Java 目录
         var url: URL = url
-        while url.path != "/" {
-            if url.lastPathComponent == "Home" && url.deletingLastPathComponent().lastPathComponent == "Contents" {
-                break
+        while !isJavaHome(url) {
+            if url.path == "/" {
+                throw JavaError.invalidURL
             }
             url = url.deletingLastPathComponent()
-        }
-        if url.path == "/" {
-            throw JavaError.invalidURL
         }
         let homeDirectory: URL = url
         // 解析 release 文件
@@ -71,14 +83,13 @@ public enum JavaSearcher {
         var type: JavaRuntime.JavaType?
         var executableURL: URL?
         var architecture: Architecture?
-        for (javaType, path) in [
-            (JavaRuntime.JavaType.jdk, "bin/java"),
-            (JavaRuntime.JavaType.jre, "jre/bin/java")
-        ] {
+        for path in ["bin/java", "jre/bin/java"] {
             let url: URL = homeDirectory.appending(path: path)
             let arch: Architecture = .architecture(of: url)
             if arch != .unknown {
-                type = javaType
+                // 只有 JDK 才自带 javac
+                let javacURL: URL = url.deletingLastPathComponent().appending(path: "javac")
+                type = FileManager.default.fileExists(atPath: javacURL.path) ? .jdk : .jre
                 executableURL = url
                 architecture = arch
                 break
@@ -111,25 +122,42 @@ public enum JavaSearcher {
         return nil
     }
     
-    private static func findJavaBundles() throws -> [URL] {
-        var bundleDirectories: [URL] = []
-        
-        for directory in javaDirectories where FileManager.default.fileExists(atPath: directory.path) {
-            bundleDirectories.append(contentsOf: try FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil))
+    private static func findJavaHomes() -> [URL] {
+        var homeDirectories: [URL] = javaDirectories.flatMap { contents(of: $0).compactMap(javaHome(at:)) }
+        homeDirectories += homebrewDirectories.flatMap {
+            contents(of: $0)
+                .filter { $0.lastPathComponent.starts(with: "openjdk") }
+                .compactMap(javaHome(at:))
         }
-        // Homebrew
-        let homebrewRoot: URL = .init(fileURLWithPath: "/opt/homebrew/opt")
-        if FileManager.default.fileExists(atPath: homebrewRoot.path) {
-            do {
-                let homebrewDirectories: [URL] = try FileManager.default.contentsOfDirectory(at: homebrewRoot, includingPropertiesForKeys: nil)
-                    .filter { $0.lastPathComponent.starts(with: "openjdk@") }
-                for directory in homebrewDirectories {
-                    bundleDirectories.append(directory.appending(path: "libexec").appending(path: "openjdk.jdk"))
-                }
-            } catch {
-                err("搜索 Homebrew 目录失败：\(error.localizedDescription)")
-            }
+        // SDKMAN 的 current、jEnv 的软链接等会指向同一个 Java，按真实路径去重
+        var visited: Set<String> = []
+        return homeDirectories.filter { visited.insert($0.resolvingSymlinksInPath().path).inserted }
+    }
+
+    /// 解析一个可能的 Java 安装目录，兼容 macOS 的 `.jdk` 包、Homebrew 与直接解压的 Java 目录。
+    /// - Returns: Java 主目录，若该目录不是 Java 安装目录则返回 `nil`。
+    private static func javaHome(at url: URL) -> URL? {
+        [
+            url,                                            // SDKMAN、asdf、mise 等直接解压的目录
+            url.appending(path: "Contents/Home"),           // macOS 的 .jdk / .bundle 包
+            url.appending(path: "libexec/openjdk.jdk/Contents/Home") // Homebrew
+        ].first(where: isJavaHome)
+    }
+
+    /// 判断目录是否为 Java 主目录。
+    private static func isJavaHome(_ url: URL) -> Bool {
+        FileManager.default.fileExists(atPath: url.appending(path: "release").path)
+    }
+
+    private static func contents(of directory: URL) -> [URL] {
+        // 大部分用户不会装全这些工具，目录不存在是常态
+        guard FileManager.default.fileExists(atPath: directory.path) else { return [] }
+        do {
+            return try FileManager.default.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)
+                .sorted { $0.path < $1.path }
+        } catch {
+            err("搜索 \(directory.path) 失败：\(error.localizedDescription)")
+            return []
         }
-        return bundleDirectories.filter { FileManager.default.fileExists(atPath: $0.appending(path: "Contents/Home/release").path) }
     }
 }

--- a/PCL.Mac/Task/MinecraftLaunchTask.swift
+++ b/PCL.Mac/Task/MinecraftLaunchTask.swift
@@ -391,7 +391,7 @@ public enum MinecraftLaunchTask {
             self.options.runningDirectory = instance.url
             self.options.repository = repository
             self.options.memory = instance.config.jvmHeapSize
-            self.options.extraJvmArguments = instance.config.jvmArguments?.splitToArguments() ?? []
+            self.options.extraJvmArguments = instance.config.jvmArguments
         }
     }
 }

--- a/PCL.Mac/Task/MinecraftLaunchTask.swift
+++ b/PCL.Mac/Task/MinecraftLaunchTask.swift
@@ -391,6 +391,7 @@ public enum MinecraftLaunchTask {
             self.options.runningDirectory = instance.url
             self.options.repository = repository
             self.options.memory = instance.config.jvmHeapSize
+            self.options.extraJvmArguments = instance.config.jvmArguments?.splitToArguments() ?? []
         }
     }
 }

--- a/PCL.Mac/ViewModels/Instance/InstanceConfigViewModel.swift
+++ b/PCL.Mac/ViewModels/Instance/InstanceConfigViewModel.swift
@@ -12,6 +12,7 @@ import Core
 class InstanceConfigViewModel: ObservableObject {
     @Published public var instance: MinecraftInstance
     @Published public var jvmHeapSize: String = ""
+    @Published public var jvmArguments: String = ""
     @Published public var javaDescription: String = "无"
     
     public var description: String {
@@ -36,6 +37,7 @@ class InstanceConfigViewModel: ObservableObject {
         self.id = id
         self.instance = instanceManager.currentRepository.instance(named: id)! // TODO: 改为安全解包
         self.jvmHeapSize = instance.config.jvmHeapSize.description
+        self.jvmArguments = instance.config.jvmArguments ?? ""
         do {
             self.javaDescription = try instance.config.javaURL.map(JavaSearcher.load(from:))?.description ?? "无"
         } catch {}
@@ -52,7 +54,14 @@ class InstanceConfigViewModel: ObservableObject {
         instance.config.jvmHeapSize = heapSize
         instance.markDirty()
     }
-    
+
+    @MainActor
+    public func setJvmArguments(_ arguments: String) {
+        let trimmed: String = arguments.trimmingCharacters(in: .whitespacesAndNewlines)
+        instance.config.jvmArguments = trimmed.isEmpty ? nil : trimmed
+        instance.markDirty()
+    }
+
     @MainActor
     public func switchJava(to runtime: JavaRuntime) throws {
         if runtime.majorVersion < instance.manifest.javaVersion.majorVersion {

--- a/PCL.Mac/ViewModels/Instance/InstanceConfigViewModel.swift
+++ b/PCL.Mac/ViewModels/Instance/InstanceConfigViewModel.swift
@@ -37,7 +37,7 @@ class InstanceConfigViewModel: ObservableObject {
         self.id = id
         self.instance = instanceManager.currentRepository.instance(named: id)! // TODO: 改为安全解包
         self.jvmHeapSize = instance.config.jvmHeapSize.description
-        self.jvmArguments = instance.config.jvmArguments ?? ""
+        self.jvmArguments = instance.config.jvmArguments.joinedToArgumentLine()
         do {
             self.javaDescription = try instance.config.javaURL.map(JavaSearcher.load(from:))?.description ?? "无"
         } catch {}
@@ -57,8 +57,7 @@ class InstanceConfigViewModel: ObservableObject {
 
     @MainActor
     public func setJvmArguments(_ arguments: String) {
-        let trimmed: String = arguments.trimmingCharacters(in: .whitespacesAndNewlines)
-        instance.config.jvmArguments = trimmed.isEmpty ? nil : trimmed
+        instance.config.jvmArguments = arguments.splitToArguments()
         instance.markDirty()
     }
 

--- a/PCL.Mac/Views/Launch/InstanceSettings/InstanceConfigPage.swift
+++ b/PCL.Mac/Views/Launch/InstanceSettings/InstanceConfigPage.swift
@@ -72,6 +72,12 @@ struct InstanceConfigPage: View {
                     }
                 MyText("MB")
             }
+            configLine(label: "JVM 参数") {
+                MyTextField(text: $viewModel.jvmArguments, placeholder: "例如 -XX:+UseG1GC -Dfile.encoding=UTF-8")
+                    .onChange(of: viewModel.jvmArguments) { newValue in
+                        viewModel.setJvmArguments(newValue)
+                    }
+            }
             HStack(spacing: 30) {
                 MyButton("切换 Java") {
                     let runtimes: [JavaRuntime] = viewModel.javaList()

--- a/PCL.Mac/Views/Launch/InstanceSettings/InstanceConfigPage.swift
+++ b/PCL.Mac/Views/Launch/InstanceSettings/InstanceConfigPage.swift
@@ -72,8 +72,8 @@ struct InstanceConfigPage: View {
                     }
                 MyText("MB")
             }
-            configLine(label: "JVM 参数") {
-                MyTextField(text: $viewModel.jvmArguments, placeholder: "例如 -XX:+UseG1GC -Dfile.encoding=UTF-8")
+            configLine(label: "额外 JVM 参数") {
+                MyTextField(text: $viewModel.jvmArguments, placeholder: "例如 -XX:+UseG1GC -Dfile.encoding=UTF-8，将被追加至原本 JVM 参数后")
                     .onChange(of: viewModel.jvmArguments) { newValue in
                         viewModel.setJvmArguments(newValue)
                     }


### PR DESCRIPTION
1. 支持自定义 JVM 启动参数

2. 我以前遇到的 无法搜索到 SDKMAN 等工具安装的 Java：

搜索路径补充 SDKMAN、asdf、mise、jEnv、Jabba、Gradle 工具链与 IntelliJ 的 `~/.jdks`等

JDK / JRE 判断由位于 `bin/` 还是 `jre/bin/` 改为同目录是否存在 `javac`。

两次提交，按需合并