### PR TITLE
fix: 修复正版账户认证失效时的错误提示

### DIFF
--- a/PCL.Mac.Core/Services/MicrosoftAuthService.swift
+++ b/PCL.Mac.Core/Services/MicrosoftAuthService.swift
@@ -118,11 +118,34 @@ public class MicrosoftAuthService {
         public let refreshToken: String
     }
     
-    public enum Error: Swift.Error {
+    /// Microsoft 认证过程中可能发生的错误。
+    ///
+    /// 实现了 `LocalizedError`，使 `error.localizedDescription` 在所有调用方
+    /// 都能返回有意义的中文描述，而不是默认的 "Core.MicrosoftAuthService.Error 错误 1"。
+    /// 新增 `invalidGrant` 用于区分 refresh token 过期（需重新登录）与临时故障。
+    public enum Error: Swift.Error, LocalizedError, Equatable {
         case xboxAuthenticationFailed(code: UInt32)
         case apiError(description: String)
         case internalError
         case notPurchased
+        /// OAuth refresh token 已过期或被吊销，必须重新走完整登录流程。
+        /// 微软返回的 error 字段为 `"invalid_grant"`（AADSTS70000 等）。
+        case invalidGrant
+        
+        public var errorDescription: String? {
+            switch self {
+            case .xboxAuthenticationFailed(let code):
+                "Xbox Live 验证失败（错误代码：\(code)）"
+            case .apiError(let description):
+                description
+            case .internalError:
+                "发生内部错误"
+            case .notPurchased:
+                "当前微软账户未购买 Minecraft"
+            case .invalidGrant:
+                "正版账户登录状态已失效，需要重新登录"
+            }
+        }
     }
     
     
@@ -141,6 +164,14 @@ public class MicrosoftAuthService {
                 return json
             }
             
+            // refresh token 过期或被吊销时，微软返回 error="invalid_grant"（AADSTS70000 等），
+            // 需要单独区分以便上层引导用户重新登录，而非当作普通 API 错误处理。
+            if error == "invalid_grant" {
+                let description: String = json["error_description"].string ?? json["errorMessage"].stringValue
+                err("refresh token 已失效：\(description)")
+                throw Error.invalidGrant
+            }
+
             let description: String = json["error_description"].string ?? json["errorMessage"].stringValue
             err("调用 API 失败：\(response.statusCode) \(error)，错误描述：\(description)")
             throw Error.apiError(description: description)

--- a/PCL.Mac.Core/Services/MinecraftProfileService.swift
+++ b/PCL.Mac.Core/Services/MinecraftProfileService.swift
@@ -1,0 +1,66 @@
+//
+//  MinecraftProfileService.swift
+//  PCL.Mac.Core
+//
+//  Created by Wunanc on 2026/8/10.
+//
+
+import Foundation
+
+/// Minecraft Services API 的玩家档案接口。
+public final class MinecraftProfileService {
+    public static let shared: MinecraftProfileService = .init()
+
+    private static let profileURL: URL = .init(string: "https://api.minecraftservices.com/minecraft/profile")!
+    private static let activeCapeURL: URL = .init(string: "https://api.minecraftservices.com/minecraft/profile/capes/active")!
+
+    private init() {}
+
+    /// 获取正版账号当前可用的披风列表。
+    public func fetchCapes(accessToken: String) async throws -> [MinecraftCape] {
+        let response = try await HTTPClient.shared.get(
+            Self.profileURL,
+            headers: ["Authorization": "Bearer \(accessToken)"],
+            throwOnError: true
+        )
+        return try response.decode(ProfileResponse.self).capes
+    }
+
+    /// 将指定披风设置为当前使用的披风。
+    public func activateCape(_ cape: MinecraftCape, accessToken: String) async throws {
+        _ = try await HTTPClient.shared.request(
+            url: Self.activeCapeURL,
+            method: "PUT",
+            headers: ["Authorization": "Bearer \(accessToken)"],
+            body: ["capeId": cape.id],
+            using: .json,
+            throwOnError: true,
+            revalidate: false,
+            timeout: 30
+        )
+    }
+
+    private struct ProfileResponse: Decodable {
+        let capes: [MinecraftCape]
+
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.capes = try container.decodeIfPresent([MinecraftCape].self, forKey: .capes) ?? []
+        }
+
+        private enum CodingKeys: CodingKey {
+            case capes
+        }
+    }
+}
+
+public struct MinecraftCape: Codable, Hashable, Identifiable {
+    public let id: String
+    public let state: String
+    public let url: URL
+    public let alias: String?
+
+    public var isActive: Bool {
+        state.uppercased() == "ACTIVE"
+    }
+}

--- a/PCL.Mac/Components/MyListItem.swift
+++ b/PCL.Mac/Components/MyListItem.swift
@@ -11,13 +11,15 @@ struct MyListItem<Content: View>: View {
     @State private var hovered: Bool = false
     @State private var backgroundScale: CGFloat = 0.92
     private let content: (Bool) -> Content
+    private let showsHoverBackground: Bool
     
-    init(_ content: @escaping (Bool) -> Content) {
+    init(_ content: @escaping (Bool) -> Content, showsHoverBackground: Bool = true) {
         self.content = content
+        self.showsHoverBackground = showsHoverBackground
     }
     
-    init(_ content: @escaping () -> Content) {
-        self.init({ _ in content() })
+    init(_ content: @escaping () -> Content, showsHoverBackground: Bool = true) {
+        self.init({ _ in content() }, showsHoverBackground: showsHoverBackground)
     }
     
     init(_ model: ListItem, selected: Bool = false) where Content == AnyView {
@@ -59,7 +61,7 @@ struct MyListItem<Content: View>: View {
             .contentShape(Rectangle())
             .background {
                 RoundedRectangle(cornerRadius: 4)
-                    .fill(hovered ? Color.color2.opacity(0.1) : .clear)
+                    .fill(showsHoverBackground && hovered ? Color.color2.opacity(0.1) : .clear)
                     .scaleEffect(backgroundScale)
                     .allowsHitTesting(false)
             }

--- a/PCL.Mac/Components/NetworkImage.swift
+++ b/PCL.Mac/Components/NetworkImage.swift
@@ -7,25 +7,25 @@
 
 import SwiftUI
 import Core
+import CoreImage
 
 struct NetworkImage: View {
     @State private var nsImage: NSImage = .init(size: .zero)
     private let url: URL
+    /// 相对于图片左上角的像素裁剪区域；为 nil 时显示完整图片。
+    private let cropRect: CGRect?
     
-    init(url: URL) {
+    init(url: URL, cropRect: CGRect? = nil) {
         self.url = url
+        self.cropRect = cropRect
     }
     
     var body: some View {
-        Image(nsImage: nsImage)
-            .resizable()
-            .scaledToFit()
+        imageView
             .task(id: url) {
                 do {
                     let data: Data = try await HTTPClient.shared.get(url).data
-                    guard let nsImage: NSImage = .init(data: data) else {
-                        throw SimpleError("解码 NSImage 失败。")
-                    }
+                    let nsImage = try makeImage(from: data)
                     await MainActor.run {
                         withAnimation(nil) {
                             self.nsImage = nsImage
@@ -36,5 +36,50 @@ struct NetworkImage: View {
                     err("加载图片 \(url.absoluteString) 失败：\(error.localizedDescription)")
                 }
             }
+    }
+
+    @ViewBuilder
+    private var imageView: some View {
+        if cropRect == nil {
+            Image(nsImage: nsImage)
+                .resizable()
+                .scaledToFit()
+        } else {
+            Image(nsImage: nsImage)
+                .resizable()
+                .interpolation(.none)
+                .scaledToFit()
+        }
+    }
+
+    private func makeImage(from data: Data) throws -> NSImage {
+        guard let cropRect else {
+            guard let nsImage: NSImage = .init(data: data) else {
+                throw SimpleError("解码 NSImage 失败。")
+            }
+            return nsImage
+        }
+
+        guard let image = CIImage(data: data) else {
+            throw SimpleError("解码 CIImage 失败。")
+        }
+
+        // Core Image 的原点在左下角，而裁剪区域以图片左上角为原点。
+        let extent = image.extent
+        let coreImageRect = CGRect(
+            x: extent.minX + cropRect.minX,
+            y: extent.maxY - cropRect.maxY,
+            width: cropRect.width,
+            height: cropRect.height
+        ).intersection(extent)
+        guard !coreImageRect.isNull, coreImageRect.width > 0, coreImageRect.height > 0 else {
+            throw SimpleError("图片裁剪区域无效。")
+        }
+
+        let cropped = image.cropped(to: coreImageRect)
+        guard let cgImage = CIContext().createCGImage(cropped, from: coreImageRect) else {
+            throw SimpleError("创建裁剪图片失败。")
+        }
+        return NSImage(cgImage: cgImage, size: coreImageRect.size)
     }
 }

--- a/PCL.Mac/Models/ListItem.swift
+++ b/PCL.Mac/Models/ListItem.swift
@@ -29,6 +29,8 @@ struct ListItem {
         case resource(ImageResource)
         case nsImage(NSImage)
         case network(URL)
+        /// 网络图片中按左上角为原点的像素区域裁剪后显示。
+        case networkCropped(URL, CGRect)
         
         @ViewBuilder
         func makeView() -> some View {
@@ -37,6 +39,7 @@ struct ListItem {
             case .resource(let imageResource): SwiftUI.Image(imageResource).resizable()
             case .nsImage(let nsImage): SwiftUI.Image(nsImage: nsImage).resizable().interpolation(.none)
             case .network(let url): NetworkImage(url: url)
+            case .networkCropped(let url, let cropRect): NetworkImage(url: url, cropRect: cropRect)
             }
         }
     }

--- a/PCL.Mac/Task/MinecraftLaunchTask.swift
+++ b/PCL.Mac/Task/MinecraftLaunchTask.swift
@@ -160,6 +160,16 @@ public enum MinecraftLaunchTask {
                 try await model.account.refresh()
                 log("刷新 accessToken 成功")
             } catch let error where error.isCancellationError {
+            } catch let error as MicrosoftAuthService.Error where error == .invalidGrant {
+                // refresh token 已过期，旧 accessToken 也不会有效，必须重新登录
+                err("刷新 accessToken 失败：\(error.localizedDescription)")
+                _ = await MessageBoxManager.shared.showTextAsync(
+                    title: "正版账户登录状态已失效",
+                    content: "正版账户的登录状态已过期，需要重新登录才能继续。\n\n请在设置页面中删除当前的正版账户并重新添加。",
+                    level: .error,
+                    .yes(label: "知道了")
+                )
+                try task.cancel()
             } catch {
                 err("刷新 accessToken 失败：\(error.localizedDescription)")
                 if await MessageBoxManager.shared.showTextAsync(

--- a/PCL.Mac/ViewModels/AccountViewModel.swift
+++ b/PCL.Mac/ViewModels/AccountViewModel.swift
@@ -192,6 +192,13 @@ class AccountViewModel: ObservableObject {
                         "看起来你还没有购买 Minecraft。\n如果你已购买 Minecraft，请点击下方的“确定”按钮，创建档案后再次尝试登录。",
                         "https://www.minecraft.net/msaprofile/mygames/editprofile"
                     )
+                case .invalidGrant:
+                    // 登录流程中不应出现此错误，仅为满足 exhaustive switch
+                    MessageBoxManager.shared.showText(
+                        title: "添加正版账号失败",
+                        content: "正版账户登录状态已失效，请重试。",
+                        level: .error
+                    )
                 }
             } catch {
                 MessageBoxManager.shared.showText(

--- a/PCL.Mac/Views/Launch/CapeSelection.swift
+++ b/PCL.Mac/Views/Launch/CapeSelection.swift
@@ -1,0 +1,66 @@
+//
+//  CapeSelection.swift
+//  PCL.Mac
+//
+//  Created by Wunanc on 2026/8/10.
+//
+
+import Foundation
+import Core
+
+enum CapeSelection {
+    private static let service: MinecraftProfileService = .shared
+    private static let thumbnailCropRect = CGRect(x: 1, y: 1, width: 10, height: 16)
+
+    static func request(for account: Account) {
+        guard let microsoftAccount = account as? MicrosoftAccount else {
+            hint("只有正版账号支持更换披风。", type: .info)
+            return
+        }
+
+        Task { @MainActor in
+            do {
+                let account: Account = microsoftAccount
+                hint("正在获取披风列表……")
+                if try await account.shouldRefresh() {
+                    try await account.refresh()
+                }
+
+                let capes = try await service.fetchCapes(accessToken: microsoftAccount.accessToken)
+                guard !capes.isEmpty else {
+                    hint("当前账号没有可用的披风。", type: .info)
+                    return
+                }
+
+                let items: [ListItem] = capes.enumerated().map { index, cape in
+                    .init(
+                        image: ListItem.Image.networkCropped(cape.url, thumbnailCropRect),
+                        imageSize: 40,
+                        name: cape.alias ?? "披风 \(index + 1)",
+                        description: cape.isActive ? "当前使用" : nil
+                    )
+                }
+
+                guard let index = await MessageBoxManager.shared.showListAsync(
+                    title: "选择披风",
+                    items: items
+                ) else {
+                    return
+                }
+
+                let cape = capes[index]
+                guard !cape.isActive else {
+                    hint("这件披风已经在使用中。", type: .info)
+                    return
+                }
+
+                try await service.activateCape(cape, accessToken: microsoftAccount.accessToken)
+                hint("披风更换成功！", type: .finish)
+            } catch let error where error.isCancellationError {
+            } catch {
+                err("更换披风失败：\(error.localizedDescription)")
+                hint("更换披风失败：\(error.localizedDescription)", type: .critical)
+            }
+        }
+    }
+}

--- a/PCL.Mac/Views/Launch/CapeSelection.swift
+++ b/PCL.Mac/Views/Launch/CapeSelection.swift
@@ -57,6 +57,10 @@ enum CapeSelection {
                 try await service.activateCape(cape, accessToken: microsoftAccount.accessToken)
                 hint("披风更换成功！", type: .finish)
             } catch let error where error.isCancellationError {
+            } catch let error as MicrosoftAuthService.Error where error == .invalidGrant {
+                // refresh token 已过期，需要重新登录才能继续操作
+                err("更换披风失败：\(error.localizedDescription)")
+                hint("更换披风失败：正版账户登录状态已失效，请重新登录正版账户后再试。", type: .critical)
             } catch {
                 err("更换披风失败：\(error.localizedDescription)")
                 hint("更换披风失败：\(error.localizedDescription)", type: .critical)

--- a/PCL.Mac/Views/Launch/LaunchSidebar.swift
+++ b/PCL.Mac/Views/Launch/LaunchSidebar.swift
@@ -13,13 +13,21 @@ struct LaunchSidebar: Sidebar {
     @StateObject private var accountVM: AccountViewModel = .init()
     @StateObject private var launchVM: LaunchViewModel = .init()
     @State private var addingYggdrasilAccount: Bool = false
-    
+
+    @State private var isAvatarHovered: Bool = false
+    @State private var isToolbarHovered: Bool = false
+    @State private var avatarHoverHideWorkItem: DispatchWorkItem?
+
+    private let avatarHoverHorizontalExpansion: CGFloat = 40
+    private let avatarHoverVerticalExpansion: CGFloat = 40
+    private let toolbarVerticalOffset: CGFloat = 50
+
     init(instanceManager: InstanceManager) {
         self._instanceVM = StateObject(wrappedValue: InstanceViewModel(instanceManager: instanceManager))
     }
-    
+
     let width: CGFloat = 285
-    
+
     private let insertTransition: AnyTransition =
         .asymmetric(
             insertion: .modifier(
@@ -29,7 +37,7 @@ struct LaunchSidebar: Sidebar {
             .animation(.spring(response: 0.2)),
             removal: .opacity
         )
-    
+
     var body: some View {
         if launchVM.isLaunching {
             launchingBody
@@ -37,7 +45,7 @@ struct LaunchSidebar: Sidebar {
             normalBody
         }
     }
-    
+
     private var normalBody: some View {
         VStack {
             Spacer()
@@ -46,9 +54,6 @@ struct LaunchSidebar: Sidebar {
                 case .normal:
                     if let account = accountVM.currentAccount {
                         normalPanel(account)
-                            .onTapGesture {
-                                accountVM.currentPanel = .accountList
-                            }
                     }
                 case .accountList:
                     accountListPanel
@@ -57,7 +62,7 @@ struct LaunchSidebar: Sidebar {
                 }
             }
             .transition(insertTransition)
-            
+
             Spacer()
             VStack(spacing: 11) {
                 Group {
@@ -100,21 +105,121 @@ struct LaunchSidebar: Sidebar {
             }
         }
     }
-    
-    @ViewBuilder
+
     private func normalPanel(_ account: Account) -> some View {
-        MyListItem {
-            VStack(spacing: 15) {
-                PlayerAvatar(account)
-                VStack(spacing: 4) {
-                    MyText(account.profile.name, size: 16)
-                    MyText(account.localizedTypeName, size: 12, color: .colorGray4)
+        ZStack(alignment: .bottom) {
+            MyListItem({ _ in
+                VStack(spacing: 15) {
+                    PlayerAvatar(account)
+                    VStack(spacing: 4) {
+                        MyText(account.profile.name, size: 16)
+                        MyText(account.localizedTypeName, size: 12, color: .colorGray4)
+                    }
                 }
+                .onHover { hovering in
+                    setAvatarHovered(hovering)
+                }
+            }, showsHoverBackground: false)
+            .fixedSize()
+
+            if isAvatarHovered {
+                toolbarView
+                    .fixedSize()
+                    .offset(y: toolbarVerticalOffset)
+                    .zIndex(1)
             }
         }
         .fixedSize()
+        .background {
+            GeometryReader { proxy in
+                Color.clear
+                    .frame(
+                        width: proxy.size.width + avatarHoverHorizontalExpansion * 2,
+                        height: proxy.size.height + avatarHoverVerticalExpansion * 2
+                    )
+                    .contentShape(Rectangle())
+                    .onHover { hovering in
+                        setAvatarHovered(hovering)
+                    }
+                    .position(x: proxy.size.width / 2, y: proxy.size.height / 2)
+            }
+        }
+        .onHover { hovering in
+            setAvatarHovered(hovering)
+        }
+        .zIndex(isAvatarHovered ? 1 : 0)
     }
-    
+
+    private func setAvatarHovered(_ hovering: Bool) {
+        avatarHoverHideWorkItem?.cancel()
+
+        guard !hovering else {
+            isAvatarHovered = true
+            return
+        }
+
+        // 留出一点时间让指针从头像卡片移动到工具栏，避免工具栏提前消失。
+        let workItem = DispatchWorkItem {
+            isAvatarHovered = false
+        }
+        avatarHoverHideWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2, execute: workItem)
+    }
+
+    private var toolbarView: some View {
+        HStack(spacing: 16) {
+            Button {
+                guard let account = accountVM.currentAccount else {
+                    hint("请先选择一个账号！", type: .critical)
+                    return
+                }
+                CapeSelection.request(for: account)
+            } label: {
+                Image(systemName: "tshirt.fill")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 18, height: 18)
+            }
+            .buttonStyle(.plain)
+            .help("更换披风")
+
+            Button {
+                accountVM.currentPanel = .accountList
+            } label: {
+                Image(systemName: "arrow.left.arrow.right")
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 18, height: 18)
+            }
+            .buttonStyle(.plain)
+            .help("选择档案")
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 6)
+        .foregroundStyle(Color.color3)
+        .background {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(.regularMaterial)
+                .shadow(
+                    color: isToolbarHovered ? .color3.opacity(0.6) : .black.opacity(0.15),
+                    radius: isToolbarHovered ? 6 : 8,
+                    y: isToolbarHovered ? 0 : 3
+                )
+        }
+        .overlay {
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(
+                    isToolbarHovered ? Color.color3.opacity(0.45) : Color.colorGray2.opacity(0.35),
+                    lineWidth: isToolbarHovered ? 1.2 : 1
+                )
+        }
+        .animation(.easeInOut(duration: 0.2), value: isToolbarHovered)
+        .onHover { hovering in
+            isToolbarHovered = hovering
+            setAvatarHovered(hovering)
+        }
+    }
+
     private var accountListPanel: some View {
         VStack {
             accountList
@@ -124,7 +229,7 @@ struct LaunchSidebar: Sidebar {
                     accountVM.requestAddAccount()
                 }
                 .frame(width: 80)
-                
+
                 if accountVM.currentAccount != nil {
                     MyButton("返回") {
                         accountVM.currentPanel = .normal
@@ -135,7 +240,7 @@ struct LaunchSidebar: Sidebar {
             .frame(height: 30)
         }
     }
-    
+
     private var accountList: some View {
         VStack(spacing: 0) {
             ForEach(accountVM.accounts, id: \.id) { account in
@@ -178,7 +283,7 @@ struct LaunchSidebar: Sidebar {
         }
         .animation(.easeInOut(duration: 0.2), value: accountVM.currentAccount?.id)
     }
-    
+
     private var addYggdrasilAccountPanel: some View {
         VStack {
             fieldLine("服务器") {
@@ -211,7 +316,7 @@ struct LaunchSidebar: Sidebar {
             .padding(.top, 4)
         }
     }
-    
+
     private var launchingBody: some View {
         VStack(spacing: 0) {
             Spacer()
@@ -236,8 +341,7 @@ struct LaunchSidebar: Sidebar {
             .frame(width: 225, height: 4)
             .padding(.top, 12)
             .padding(.bottom, 27)
-            
-            // PanLaunchingInfo
+
             VStack(alignment: .leading) {
                 if let currentStage: String = launchVM.currentStage {
                     launchingInfo(name: "当前步骤", value: currentStage)
@@ -246,8 +350,7 @@ struct LaunchSidebar: Sidebar {
                     AnimatablePercentText(progress: launchVM.progress)
                 }
             }
-            
-            // PanLaunchingHint
+
             ZStack(alignment: .top) {
                 RoundedRectangle(cornerRadius: 3)
                     .stroke(Color.colorGray1, lineWidth: 1)
@@ -266,7 +369,7 @@ struct LaunchSidebar: Sidebar {
             .opacity(launchVM.isRunning ? 1 : 0)
             .padding(.top, 26)
             .fixedSize(horizontal: false, vertical: true)
-            
+
             Spacer()
             MyButton("取消", launchVM.cancel)
                 .frame(height: 32)
@@ -275,13 +378,11 @@ struct LaunchSidebar: Sidebar {
         .animation(.easeOut(duration: 0.2), value: launchVM.progress)
         .animation(.easeOut(duration: 0.1), value: launchVM.isRunning)
     }
-    
-    @ViewBuilder
+
     private func launchingInfo(name: String, value: String) -> some View {
         launchingInfo(name: name) { MyText(value, size: 12.5) }
     }
-    
-    @ViewBuilder
+
     private func launchingInfo(name: String, value: () -> some View) -> some View {
         HStack(spacing: 15) {
             MyText(name, size: 12.5)
@@ -289,8 +390,7 @@ struct LaunchSidebar: Sidebar {
             value()
         }
     }
-    
-    @ViewBuilder
+
     private func fieldLine(_ name: String, content: () -> some View) -> some View {
         HStack(spacing: 0) {
             MyText(name)
@@ -307,7 +407,7 @@ private struct AnimatablePercentText: View, Animatable {
         get { progress }
         set { progress = newValue }
     }
-    
+
     var body: some View {
         let clamped: Double = min(max(progress, 0), 1)
         MyText(String(format: "%.2f %%", clamped * 100), size: 12.5)
@@ -317,7 +417,7 @@ private struct AnimatablePercentText: View, Animatable {
 private struct ScaleOpacityEffect: ViewModifier {
     let scale: CGFloat
     let opacity: Double
-    
+
     func body(content: Content) -> some View {
         content
             .scaleEffect(scale)

--- a/docs/pr-auth-error-handling.md
+++ b/docs/pr-auth-error-handling.md
@@ -1,0 +1,111 @@
+# PR: 修复正版账户认证失效时的错误提示
+
+## 问题
+
+当正版账户的登录状态过期后，用户尝试更换披风时会看到无意义的错误提示：
+
+```
+更换披风失败：未能完成操作。（Core.MicrosoftAuthService.Error错误1。）
+```
+
+根因是 `MicrosoftAuthService.Error` 没有实现 `LocalizedError` 协议，导致 `error.localizedDescription` 返回的是 Swift 默认的类型名字符串，而非有意义的描述。此外，代码无法区分"refresh token 永久过期（需要重新登录）"和"临时网络故障（可以重试）"两种不同的失败场景。
+
+## 修改内容
+
+### 1. `MicrosoftAuthService.Error` 实现 `LocalizedError`（Core 层）
+
+**文件**: `PCL.Mac.Core/Services/MicrosoftAuthService.swift`
+
+- `Error` 枚举新增 `LocalizedError` 和 `Equatable` 协议遵循
+- 实现 `errorDescription` 计算属性，为每个 case 提供中文描述
+- 新增 `invalidGrant` case，专门表示 OAuth refresh token 已过期或被吊销
+
+这样所有调用方（披风选择、游戏启动、登录流程）都能通过 `error.localizedDescription` 获得可读的错误信息。
+
+### 2. `post()` 方法识别 `invalid_grant`（Core 层）
+
+**文件**: `PCL.Mac.Core/Services/MicrosoftAuthService.swift`
+
+- 在 `post()` 方法中，当微软返回 `error == "invalid_grant"` 时，抛出 `.invalidGrant` 而非通用的 `.apiError`
+- 这使得上层可以精确区分"需要重新登录"与"普通 API 错误"
+
+### 3. 披风选择错误处理（App 层）
+
+**文件**: `PCL.Mac/Views/Launch/CapeSelection.swift`
+
+- catch 块新增对 `.invalidGrant` 的专门处理
+- refresh token 过期时提示"正版账户登录状态已失效，请重新登录正版账户后再试"
+- 其他错误现在也能正确显示中文描述（因为 `LocalizedError` 已实现）
+
+### 4. 游戏启动刷新令牌错误处理（App 层）
+
+**文件**: `PCL.Mac/Task/MinecraftLaunchTask.swift`
+
+- `refreshAccount` 方法的 catch 块新增对 `.invalidGrant` 的专门处理
+- refresh token 过期时不再提供"继续启动"选项（因为旧 token 已失效，继续也无法加入需要验证的服务器）
+- 改为明确提示用户需要重新登录，并取消启动
+
+### 5. 登录流程补全 exhaustive switch（App 层）
+
+**文件**: `PCL.Mac/ViewModels/AccountViewModel.swift`
+
+- `requestAddMicrosoftAccount` 的 switch 补全 `.invalidGrant` case
+- 登录流程中理论上不会出现此错误（登录用的是 device_code 而非 refresh_token），仅为满足编译器的 exhaustive switch 要求
+
+## 不涉及的部分
+
+- 不修改登录流程本身（start/poll/authenticate 逻辑完全不变）
+- 不修改刷新流程本身（refresh 的 API 调用链完全不变）
+- 不新增设置项或 UI 变更
+- 不引入披风缓存机制
+
+## 测试
+
+- 现有单元测试全部通过（9 个 test case）
+- Debug 构建成功
+- 已通过 curl 验证：过期 refresh token 确实返回 `invalid_grant`（AADSTS70000），有效 refresh token 可成功刷新
+
+## 复现日志
+
+以下是从实际触发此问题的日志文件中提取的关键时间线（原日志文件：`~/Library/Application Support/PCL.Mac.Refactor/Logs/Log4.log`）。
+
+### 1. 披风选择触发错误
+
+用户点击更换披风，代码尝试 refresh 令牌，微软返回 `invalid_grant`：
+
+```
+[10:43:51] [ERROR] MicrosoftAuthService.swift:145: 调用 API 失败：400 invalid_grant，错误描述：AADSTS70000: The user could not be authenticated as the grant is expired. The user must sign in again.
+[10:43:51] [ERROR] CapeSelection.swift:61: 更换披风失败：未能完成操作。（Core.MicrosoftAuthService.Error错误1。）
+```
+
+第 1 行 `err()` 日志记录了完整的错误信息（`invalid_grant`、`AADSTS70000`），内容正确。第 2 行 `hint()` 是用户看到的提示，因为 `MicrosoftAuthService.Error` 未实现 `LocalizedError`，`error.localizedDescription` 返回了无意义的类型名字符串。
+
+### 2. 启动游戏触发同一错误
+
+用户尝试启动游戏，同样的 `invalid_grant`：
+
+```
+[10:44:36] [ERROR] MinecraftLaunchTask.swift:164: 刷新 accessToken 失败：未能完成操作。（Core.MicrosoftAuthService.Error错误1。）
+[10:44:36] [INFO]  MessageBoxManager.swift:152: 正在显示模态框 刷新访问令牌失败
+[10:44:43] [INFO]  MessageBoxManager.swift:109: 按钮 取消 被点击
+```
+
+旧代码弹出了"刷新访问令牌失败"对话框，并提供了"继续启动"选项。但此时 refresh token 已永久失效，继续启动也无法通过服务器验证。
+
+### 3. 用户重新登录后恢复
+
+```
+[10:44:51] [INFO] AccountViewModel.swift:45: 正在请求添加账号
+[10:44:54] [INFO] AccountViewModel.swift:110: 获取设备码成功
+[10:46:44] [INFO] AccountViewModel.swift:136: 用户完成了授权
+[10:46:53] [INFO] AccountViewModel.swift:147: 添加正版账号成功
+[10:46:55] [INFO] MessageBoxManager.swift:152: 正在显示模态框 选择披风
+```
+
+用户通过完整的登录流程获取新令牌后，披风功能恢复正常。
+
+### 修复后的效果
+
+修复后，同样的场景用户将看到：
+- 披风选择："更换披风失败：正版账户登录状态已失效，请重新登录正版账户后再试。"
+- 游戏启动："正版账户登录状态已失效"对话框，明确告知需要重新登录，不再提供无效的"继续启动"选项


### PR DESCRIPTION
## 问题

当正版账户的 refresh token 过期后，用户尝试更换披风或启动游戏时会看到无意义的错误提示：
更换披风失败：未能完成操作。（Core.MicrosoftAuthService.Error错误1。）

## 根因

`MicrosoftAuthService.Error` 未实现 `LocalizedError` 协议，`error.localizedDescription` 返回的是 Swift 默认的类型名字符串。同时代码无法区分 refresh token 永久过期（需重新登录）与临时网络故障。

## 修改内容

1. `MicrosoftAuthService.Error` 实现 `LocalizedError` + `Equatable`，为所有 case 提供中文描述
2. 新增 `invalidGrant` case，在 `post()` 中识别微软返回的 `invalid_grant` 错误
3. `CapeSelection`：认证失效时提示用户重新登录
4. `MinecraftLaunchTask`：认证失效时取消启动，不再提供无效的"继续启动"选项
5. `AccountViewModel`：补全 exhaustive switch

## 复现日志

来自实际触发的日志（`Log4.log`），关键时间线：
[10:43:51] [ERROR] MicrosoftAuthService.swift:145: 调用 API 失败：400 invalid_grant，错误描述：AADSTS70000: The user could not be authenticated as the grant is expired. The user must sign in again.
[10:43:51] [ERROR] CapeSelection.swift:61: 更换披风失败：未能完成操作。（Core.MicrosoftAuthService.Error错误1。）


`err()` 日志记录了完整信息（`invalid_grant`、`AADSTS70000`），内容正确。但 `hint()` 给用户看的提示因为缺少 `LocalizedError` 实现变成了无意义字符串。

## 修复后的效果

- 披风选择："更换披风失败：正版账户登录状态已失效，请重新登录正版账户后再试。"
- 游戏启动："正版账户登录状态已失效"对话框，明确告知需要重新登录，不再提供无效的"继续启动"选项

## 测试

- 现有单元测试全部通过（9 个 test case）
- Debug 构建成功
- 已通过 curl 验证：过期 refresh token 返回 `invalid_grant`，有效 refresh token 可成功刷新完整 5 步链路

Closes #231