### PR TITLE
fix: ModrinthVersion primaryFile 判断不完全正确

### DIFF
--- a/PCL.Mac/ViewModels/ResourceInstallViewModel.swift
+++ b/PCL.Mac/ViewModels/ResourceInstallViewModel.swift
@@ -74,7 +74,7 @@ class ResourceInstallViewModel: ObservableObject {
                     datePublished: ProjectListItemModel.formatLastUpdate(version.datePublished),
                     requiredDependencies: dependencies,
                     type: version.type,
-                    primaryFile: version.files.filter(\.primary).first,
+                    primaryFile: version.files.filter(\.primary).first ?? version.files.first,
                     gameVersion: key.version.id,
                     loader: key.loader
                 )


### PR DESCRIPTION
当 `ModrinthVersion` 中没有 `primary=true` 的文件时，第一个文件将被当做主要文件。

https://docs.modrinth.com/api/operations/getprojectversions