### PR TITLE
fix: 缓解设置窗口按钮位置在 macOS 12 上导致的崩溃问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ __MACOSX/
 # Xcode
 PCL.Mac.xcodeproj/xcuserdata/
 PCL.Mac.xcodeproj/project.xcworkspace/xcuserdata/
+
+build.xcarchive

--- a/PCL.Mac/App/AppWindow.swift
+++ b/PCL.Mac/App/AppWindow.swift
@@ -8,38 +8,111 @@
 import SwiftUI
 import Core
 
-fileprivate let isMacOS26: Bool = ProcessInfo.processInfo.operatingSystemVersion.majorVersion == 26
-fileprivate let isMacOS14OrLater: Bool = ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 14
+private final class TrafficLightView: NSView {
+    private let buttons: [NSButton]
+    
+    init(styleMask: NSWindow.StyleMask) {
+        self.buttons = [
+            NSWindow.standardWindowButton(.closeButton, for: styleMask),
+            NSWindow.standardWindowButton(.miniaturizeButton, for: styleMask)
+        ].compactMap { $0 }
+        super.init(frame: .zero)
+        
+        buttons.forEach { button in
+            addSubview(button)
+        }
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override var isFlipped: Bool { true }
+    
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: 84, height: 84)
+    }
+    
+    override func layout() {
+        super.layout()
+        
+        buttons[0].frame.origin = .init(x: 0, y: 0)
+        buttons[1].frame.origin = .init(x: 22, y: 0)
+    }
+    
+    func connect(to window: NSWindow) {
+        let actions: [Selector] = [
+            #selector(NSWindow.performClose(_:)),
+            #selector(NSWindow.miniaturize(_:))
+        ]
+        for (button, action) in zip(buttons, actions) {
+            button.target = window
+            button.action = action
+        }
+    }
+}
+
+private final class WindowContentView: NSView {
+    private let hostingView: NSView
+    private let trafficLights: NSView
+    
+    init(hostingView: NSView, trafficLights: NSView) {
+        self.hostingView = hostingView
+        self.trafficLights = trafficLights
+        super.init(frame: .zero)
+        addSubview(hostingView)
+        addSubview(trafficLights)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override var isFlipped: Bool { true }
+    
+    override func layout() {
+        super.layout()
+        hostingView.frame = self.bounds
+        
+        trafficLights.frame = CGRect(
+            x: 18,
+            y: 18,
+            width: 84,
+            height: 84
+        )
+    }
+}
 
 class AppWindow: NSWindow {
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { true }
     
     init(instanceManager: InstanceManager) {
+        let styleMask: NSWindow.StyleMask = [
+            .titled, .closable, .resizable, .miniaturizable, .fullSizeContentView
+        ]
         super.init(
             contentRect: .init(x: 0, y: 0, width: 1000, height: 550),
-            styleMask: [.titled, .closable, .resizable, .miniaturizable, .fullSizeContentView],
+            styleMask: styleMask,
             backing: .buffered, defer: false
         )
-        self.titleVisibility = .hidden
-        self.titlebarAppearsTransparent = true
+        titleVisibility = .hidden
+        titlebarAppearsTransparent = true
         
-        self.contentView = NSHostingView(rootView: RootView(instanceManager: instanceManager))
+        let hostingView = NSHostingView(rootView: RootView(instanceManager: instanceManager))
         
-        self.setFrameAutosaveName("AppWindow")
-        self.center()
-    }
-    
-    override func layoutIfNeeded() {
-        super.layoutIfNeeded()
-        if let close = self.standardWindowButton(.closeButton),
-           let min = self.standardWindowButton(.miniaturizeButton),
-           let zoom = self.standardWindowButton(.zoomButton) {
-            if isMacOS14OrLater {
-                close.frame.origin = CGPoint(x: isMacOS26 ? 18 : 16, y: isMacOS26 ? 0 : -4)
-                min.frame.origin = CGPoint(x: close.frame.maxX + (isMacOS26 ? 8 : 6), y: close.frame.minY)
-            }
-            zoom.frame.origin = CGPoint(x: 64, y: 64)
+        for button in [NSWindow.ButtonType.closeButton, .miniaturizeButton, .zoomButton] {
+            standardWindowButton(button)?.isHidden = true
         }
+        
+        let trafficLights = TrafficLightView(styleMask: styleMask)
+        trafficLights.connect(to: self)
+        let containerView = WindowContentView(hostingView: hostingView, trafficLights: trafficLights)
+        contentView = containerView
+        
+        setFrameAutosaveName("AppWindow")
+        center()
     }
 }

--- a/PCL.Mac/App/AppWindow.swift
+++ b/PCL.Mac/App/AppWindow.swift
@@ -8,111 +8,44 @@
 import SwiftUI
 import Core
 
-private final class TrafficLightView: NSView {
-    private let buttons: [NSButton]
-    
-    init(styleMask: NSWindow.StyleMask) {
-        self.buttons = [
-            NSWindow.standardWindowButton(.closeButton, for: styleMask),
-            NSWindow.standardWindowButton(.miniaturizeButton, for: styleMask)
-        ].compactMap { $0 }
-        super.init(frame: .zero)
-        
-        buttons.forEach { button in
-            addSubview(button)
-        }
-    }
-    
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    override var isFlipped: Bool { true }
-    
-    override var intrinsicContentSize: NSSize {
-        NSSize(width: 84, height: 84)
-    }
-    
-    override func layout() {
-        super.layout()
-        
-        buttons[0].frame.origin = .init(x: 0, y: 0)
-        buttons[1].frame.origin = .init(x: 22, y: 0)
-    }
-    
-    func connect(to window: NSWindow) {
-        let actions: [Selector] = [
-            #selector(NSWindow.performClose(_:)),
-            #selector(NSWindow.miniaturize(_:))
-        ]
-        for (button, action) in zip(buttons, actions) {
-            button.target = window
-            button.action = action
-        }
-    }
-}
+fileprivate let osMajorVersion = ProcessInfo.processInfo.operatingSystemVersion.majorVersion
 
-private final class WindowContentView: NSView {
-    private let hostingView: NSView
-    private let trafficLights: NSView
-    
-    init(hostingView: NSView, trafficLights: NSView) {
-        self.hostingView = hostingView
-        self.trafficLights = trafficLights
-        super.init(frame: .zero)
-        addSubview(hostingView)
-        addSubview(trafficLights)
-    }
-    
-    @available(*, unavailable)
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    override var isFlipped: Bool { true }
-    
-    override func layout() {
-        super.layout()
-        hostingView.frame = self.bounds
-        
-        trafficLights.frame = CGRect(
-            x: 18,
-            y: 18,
-            width: 84,
-            height: 84
-        )
-    }
-}
-
-class AppWindow: NSWindow {
+class AppWindow: NSWindow, NSWindowDelegate {
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { true }
     
     init(instanceManager: InstanceManager) {
-        let styleMask: NSWindow.StyleMask = [
-            .titled, .closable, .resizable, .miniaturizable, .fullSizeContentView
-        ]
         super.init(
             contentRect: .init(x: 0, y: 0, width: 1000, height: 550),
-            styleMask: styleMask,
+            styleMask: [.titled, .closable, .resizable, .miniaturizable, .fullSizeContentView],
             backing: .buffered, defer: false
         )
-        titleVisibility = .hidden
-        titlebarAppearsTransparent = true
+        self.titleVisibility = .hidden
+        self.titlebarAppearsTransparent = true
         
-        let hostingView = NSHostingView(rootView: RootView(instanceManager: instanceManager))
+        self.standardWindowButton(.zoomButton)?.isHidden = true
         
-        for button in [NSWindow.ButtonType.closeButton, .miniaturizeButton, .zoomButton] {
-            standardWindowButton(button)?.isHidden = true
+        self.contentView = NSHostingView(rootView: RootView(instanceManager: instanceManager))
+        self.delegate = self
+        
+        self.setFrameAutosaveName("AppWindow")
+        self.center()
+    }
+    
+    func windowDidUpdate(_ notification: Notification) {
+        guard osMajorVersion >= 14 else { return }
+        
+        guard let close = standardWindowButton(.closeButton),
+              let titlebarView = close.superview else {
+            return
         }
         
-        let trafficLights = TrafficLightView(styleMask: styleMask)
-        trafficLights.connect(to: self)
-        let containerView = WindowContentView(hostingView: hostingView, trafficLights: trafficLights)
-        contentView = containerView
+        let offset = osMajorVersion >= 26 ? 9 : 11
+        let origin = CGPoint(x: offset, y: -offset)
+        guard titlebarView.frame.origin != origin else {
+            return
+        }
         
-        setFrameAutosaveName("AppWindow")
-        center()
+        titlebarView.frame.origin = origin
     }
 }


### PR DESCRIPTION
不再在 macOS 12/13 上设置窗口按钮位置，以缓解崩溃问题。

已在 macOS 12 虚拟机 上通过测试。

Assisted-By: opencode:gpt-5.6-luna